### PR TITLE
remove raw .css from built RequireJS sample

### DIFF
--- a/bower/README.md
+++ b/bower/README.md
@@ -1,3 +1,9 @@
+questions:
+why is package.json private > true?
+why the requirement to copy/paste to a new esrijs-bower-requirejs folder?
+why are folders other than `app` copied into the `dist` folder?
+why is a bunch of `.css` and `.js` content loaded from those folders when you launch `dist/index.html`?
+
 # arcgis-js-api build tools
 ======
 

--- a/bower/README.md
+++ b/bower/README.md
@@ -1,9 +1,3 @@
-questions:
-why is package.json private > true?
-why the requirement to copy/paste to a new esrijs-bower-requirejs folder?
-why are folders other than `app` copied into the `dist` folder?
-why is a bunch of `.css` and `.js` content loaded from those folders when you launch `dist/index.html`?
-
 # arcgis-js-api build tools
 ======
 
@@ -12,7 +6,7 @@ You can read more about Bower [here](http://bower.io/).
 
 ## Why
 You would use the Bower download of the ArcGIS API for JavaScript if you wanted to create local builds of your application.
-This is similar to what you can do with the [JavaScript Optimzer](https://jso.arcgis.com/) but locally.
+This is similar to what you can do with the [JavaScript Optimizer](https://jso.arcgis.com/) but locally.
 This can also provide an improved debugging experience as you will know which module an error originates from.
 
 ## Dojo

--- a/bower/dojo/package.json
+++ b/bower/dojo/package.json
@@ -1,8 +1,7 @@
 {
   "name": "arcgis-js-api-sample-app",
   "version": "1.0.0",
-  "private": true,
-  "description": "",
+  "description": "Sample application for building the ArcGIS API for JavaScript using Bower and Dojo",
   "repository": {
     "url": "https://github.com/Esri/jsapi-resources/bower/dojo"
   },

--- a/bower/requirejs/Gruntfile.js
+++ b/bower/requirejs/Gruntfile.js
@@ -1,5 +1,5 @@
 module.exports = function (grunt) {
-  // Build customizations would be left up to developer to implement.
+  // additional build customizations are up to the developer to implement.
   grunt.loadNpmTasks('grunt-contrib-requirejs');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-clean');
@@ -112,9 +112,25 @@ module.exports = function (grunt) {
           },
           throwWhen: { optimize: false  }
         }
+      },
+      esricss: {
+        options: {
+          cwd: './',
+          cssIn: './src/esri/css/esri.css',
+          out: './dist/esri/css/esri.css',
+          optimizeCss: 'standard'
+        }
+      },
+      dijitcss: {
+        options: {
+          cwd: './',
+          cssIn: './src/dijit/themes/nihilo/nihilo.css',
+          out: './dist/dijit/themes/nihilo/nihilo.css',
+          optimizeCss: 'standard'
+        }
       }
     }
   });
 
-  grunt.registerTask('build', ['clean', 'requirejs:support', 'requirejs:single', 'copy']);
+  grunt.registerTask('build', ['clean', 'requirejs:support', 'requirejs:single', 'requirejs:esricss', 'requirejs:dijitcss', 'copy']);
 };

--- a/bower/requirejs/package.json
+++ b/bower/requirejs/package.json
@@ -1,8 +1,7 @@
 {
   "name": "arcgis-js-api-sample-app",
   "version": "1.0.0",
-  "private": true,
-  "description": "",
+  "description": "Sample application for building the ArcGIS API for JavaScript using Bower and RequireJS",
   "repository": {
     "url": "https://github.com/Esri/jsapi-resources/bower/requirejs"
   },


### PR DESCRIPTION
work in progress to resolve #18

* fixed a few typos and added package.json descriptions
* removed `private` tags (let me know if you meant to keep those)
* implemented @odoe's suggestion in the RequireJS `Gruntfile.js` (~~not~~ working ~~*yet*~~)

to do:
- [x] ~~resolve the CSS problem (i'm still seeing the same individual files load)~~ browser cache strikes again.
- [x] why does the RequireJS sample has both `index.html` (unbuilt) and `built.html`?  the dojo sample only has `index.html`.
> i see now that including built.html and copying it into the `dist`folder as `index.html` on the fly is what allows developers to debug the raw source and create their production `.html` purely using build tools.  i'll see if i can find a way to clarify that in the doc.

- [x] do we need to copy raw unconcatenated source files into the `dist` directory?  i was expecting only to find the built `.js` and `.css`.