### PR TITLE
update 3.x dojo project path in package.json

### DIFF
--- a/3.x/bower/dojo/package.json
+++ b/3.x/bower/dojo/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Sample application for building the ArcGIS API for JavaScript using Bower and Dojo",
   "repository": {
-    "url": "https://github.com/Esri/jsapi-resources/bower/dojo"
+    "url": "https://github.com/Esri/jsapi-resources/3.x/bower/dojo"
   },
   "scripts": {
     "preinstall": "bower install",

--- a/3.x/bower/requirejs/package.json
+++ b/3.x/bower/requirejs/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Sample application for building the ArcGIS API for JavaScript using Bower and RequireJS",
   "repository": {
-    "url": "https://github.com/Esri/jsapi-resources/bower/requirejs"
+    "url": "https://github.com/Esri/jsapi-resources/3.x/bower/requirejs"
   },
   "scripts": {
     "preinstall": "bower install",

--- a/4.x/bower/requirejs/package.json
+++ b/4.x/bower/requirejs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "",
   "repository": {
-    "url": "https://github.com/Esri/jsapi-resources/bower/requirejs"
+    "url": "https://github.com/Esri/jsapi-resources/4.x/bower/requirejs"
   },
   "scripts": {
     "preinstall": "bower install",


### PR DESCRIPTION
i believe this resolves #22.  not following @dbened-denver-water's suggestion to a *t*, but rather following the convention in the `4.x` directory:

https://github.com/Esri/jsapi-resources/blob/master/4.x/bower/dojo/package.json#L7