### PR TITLE
Fix definition of PrintTask oncomplete handler (fixes #33)

### DIFF
--- a/3.x/typescript/arcgis-js-api.d.ts
+++ b/3.x/typescript/arcgis-js-api.d.ts
@@ -15184,7 +15184,7 @@ declare module "esri/tasks/PrintTask" {
      */
     execute(printParameters: PrintParameters, callback?: Function, errback?: Function): any;
     /** Fired when the print operation is complete. */
-    on(type: "complete", listener: (event: { url: string; target: PrintTask }) => void): esri.Handle;
+    on(type: "complete", listener: (event: { result: { url: string; }; target: PrintTask }) => void): esri.Handle;
     /** Fired when an error occurs while executing the print task. */
     on(type: "error", listener: (event: { error: Error; target: PrintTask }) => void): esri.Handle;
     on(type: string, listener: (event: any) => void): esri.Handle;


### PR DESCRIPTION
A fix to match the type definition with the situation at runtime (esri-js-api 3.17), where `PrintTask`'s `on` `"complete"` handler receives the `url` wrapped into the 'result' property of the callback argument instead of being a direct property of the passed argument, as specified both in current definition and ESRI official documentation. More details in the related issue.

