### PR TITLE
make sure typescript demo is plug and play in Atom too

### DIFF
--- a/4.x/typescript/demo/tsconfig.json
+++ b/4.x/typescript/demo/tsconfig.json
@@ -8,7 +8,8 @@
     "target": "es5",
     "experimentalDecorators": true,
     "preserveConstEnums": true,
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "types": [ "arcgis-js-api" ]
   },
   "include": [
     "./app/*"


### PR DESCRIPTION
this (temporary) tweak hooks up intellisense and automatic recompile via [`atom-typescript`](https://atom.io/packages/atom-typescript) too.

<img width="582" alt="screenshot 2017-01-17 14 26 50" src="https://cloud.githubusercontent.com/assets/3011734/22042832/aa96496c-dcc1-11e6-9d7d-32cc3ac746cc.png">

reference:
https://github.com/TypeStrong/atom-typescript/blob/master/docs/faq.md#declaration-packages-types-are-not-loaded.