### PR TITLE
Frameworks

### DIFF
--- a/frameworks/README.md
+++ b/frameworks/README.md
@@ -1,0 +1,66 @@
+# Using the ArcGIS API for JavaScript with Frameworks
+
+There are two overall approaches when integrating the [ArcGIS API for JavaScript] with JavaScript frameworks like [Angular], [Ember], or [React].
+
+## The Map Centric Approach
+
+This approach is characterized by using framework components in an ArcGIS API for JavaScript application. This approach works well when:
+ - the map is the primary source of application state
+ - your developers are mainly interested in a framework's component architecture, or "view layer", as an alternative to [Dojo's Dijit](https://dojotoolkit.org/reference-guide/1.10/dijit/info.html)
+
+This approach works best with frameworks like [React] where the component architecture can easily be used independently of parts of the framework or ecosystem (such as the router, data stores, tooling, etc). In contrast it is difficult to use a full featured and strongly opinionated framework like [Ember] with this approach.
+
+### Examples
+
+The [ArcGIS API for JavaScript Samples ](https://developers.arcgis.com/javascript/latest/sample-code/index.html) include a few examples of this approach with step by step instructions on how to use framework components in an ArcGIS API for JavaScript application.
+
+ - [Angular 1](https://developers.arcgis.com/javascript/latest/sample-code/widgets-frameworks-angular/index.html)
+ - [React](https://developers.arcgis.com/javascript/latest/sample-code/widgets-frameworks-react/index.html)
+
+## The Framework First Approach
+
+In contrast, the framework first approach is characterized by using the ArcGIS API for JavaScript in an application built with a Framework. This approach works well when:
+ - the application state comes primarily from outside the map (i.e. routable URLs or data stores)
+ - your developers want to use the conventions and tooling that are typically used with the framework
+ - the map is only used on certain routes and/or you want to lazy load the ArcGIS API for JavaScript
+
+Using this kind of approach usually requires using a special build configuration and/or a helper library to load the ArcGIS API for JavaScript modules.
+
+## Examples
+
+Below are links to tools that will help you use the ArcGIS API for JavaScript in applications built with some of the more popular JavaScript frameworks, as well as examples of how to use those tools.
+
+### Angular 1
+
+[angular-esri-map](https://github.com/Esri/angular-esri-map) is a library of reusable directives and services to help you use Esri maps and data in your Angular 1 applications.
+
+Example Applications:
+ - [angular-esri-map Examples](http://esri.github.io/angular-esri-map/)
+ - [A simple example of how to roll your own AngularJS directive to show an Esri map for a focused workflow](https://github.com/tomwayson/angular-parcel-map)
+ - [Ionic app demonstrating how to use the Esri ArcGIS API for JavaScript](https://github.com/jwasilgeo/ionic-esri-map)
+
+### Angular
+
+For Angular 2 and above, there are a couple of libraries to help you use the ArcGIS API for JavaScript.  [angular2-esri-loader](https://github.com/tomwayson/angular2-esri-loader) is an Angular service to help you load modules from the ArcGIS API for JavaScript (either 3.x or 4.x). [angular2-esri4-components](https://github.com/kgs916/angular2-esri4-components) is set of reusable Angular components to work with ArcGIS API for JavaScript v4.x.
+
+Example Applications:
+ - [Example of how to to use the ArcGIS API for JavaScript in an Angular CLI app](https://github.com/tomwayson/esri-angular-cli-example)
+ - [Esri-playground: Angular 2 & Esri 4](https://github.com/jwasilgeo/angular2-esri-playground)
+ - [Example app using the ArcGIS API for JavaScript v3 in an Angular2 app](https://github.com/tomwayson/angular2-esri-example)
+ - [An example mapping application using ArcGIS API for JavaScript v4 ](https://github.com/kgs916/ng2cli-esri4)
+
+### Ember
+
+[ember-cli-amd](https://github.com/Esri/ember-cli-amd) is an [EmberCLI](https://ember-cli.com/) addon for using AMD libraries that helps you load modules from the ArcGIS API for JavaScript (either 3.x or 4.x) in an Ember application.
+
+Example Applications:
+- [ArcGIS Open Data](http://opendata.arcgis.com/) is built using ember-cli-amd
+
+### React
+TODO
+
+[ArcGIS API for JavaScript]:https://developers.arcgis.com/javascript/
+[Angular]:https://angular.io/
+[Ember]:http://emberjs.com/
+[React]:https://facebook.github.io/react/
+[Vue.js]:https://vuejs.org/

--- a/frameworks/README.md
+++ b/frameworks/README.md
@@ -8,14 +8,20 @@ This approach is characterized by using framework components in an ArcGIS API fo
  - the map is the primary source of application state
  - your developers are mainly interested in a framework's component architecture, or "view layer", as an alternative to [Dojo's Dijit](https://dojotoolkit.org/reference-guide/1.10/dijit/info.html)
 
-This approach works best with frameworks like [React] where the component architecture can easily be used independently of parts of the framework or ecosystem (such as the router, data stores, tooling, etc). In contrast it is difficult to use a full featured and strongly opinionated framework like [Ember] with this approach.
+This approach works best with frameworks like [React] where the component architecture can easily be used independently of other parts of the framework or ecosystem (such as the router, data stores, tooling, etc). In contrast it is difficult to use a full featured and strongly opinionated framework like [Ember] with this approach.
 
 ### Examples
 
 The [ArcGIS API for JavaScript Samples ](https://developers.arcgis.com/javascript/latest/sample-code/index.html) include a few examples of this approach with step by step instructions on how to use framework components in an ArcGIS API for JavaScript application.
 
- - [Angular 1](https://developers.arcgis.com/javascript/latest/sample-code/widgets-frameworks-angular/index.html)
- - [React](https://developers.arcgis.com/javascript/latest/sample-code/widgets-frameworks-react/index.html)
+ - [Angular 1 Sample](https://developers.arcgis.com/javascript/latest/sample-code/widgets-frameworks-angular/index.html)
+ - [React Sample](https://developers.arcgis.com/javascript/latest/sample-code/widgets-frameworks-react/index.html)
+
+These additional examples demonstrate this approach by creating components from each of these frameworks and using them in an ArcGIS API for JavaScript app:
+
+ - [Angular 2](http://odoe.net/blog/angular-2-with-arcgis-js-api/)
+ - [Vue.js](http://odoe.net/blog/using-vuejs-arcgis-api-javascript/)
+ - [React](https://geonet.esri.com/people/odoe/blog/2015/04/01/esrijs-with-reactjs-updated)
 
 ## The Framework First Approach
 
@@ -28,36 +34,11 @@ Using this kind of approach usually requires using a special build configuration
 
 ## Examples
 
-Below are links to tools that will help you use the ArcGIS API for JavaScript in applications built with some of the more popular JavaScript frameworks, as well as examples of how to use those tools.
-
-### Angular 1
-
-[angular-esri-map](https://github.com/Esri/angular-esri-map) is a library of reusable directives and services to help you use Esri maps and data in your Angular 1 applications.
-
-Example Applications:
- - [angular-esri-map Examples](http://esri.github.io/angular-esri-map/)
- - [A simple example of how to roll your own AngularJS directive to show an Esri map for a focused workflow](https://github.com/tomwayson/angular-parcel-map)
- - [Ionic app demonstrating how to use the Esri ArcGIS API for JavaScript](https://github.com/jwasilgeo/ionic-esri-map)
-
-### Angular
-
-For Angular 2 and above, there are a couple of libraries to help you use the ArcGIS API for JavaScript.  [angular2-esri-loader](https://github.com/tomwayson/angular2-esri-loader) is an Angular service to help you load modules from the ArcGIS API for JavaScript (either 3.x or 4.x). [angular2-esri4-components](https://github.com/kgs916/angular2-esri4-components) is set of reusable Angular components to work with ArcGIS API for JavaScript v4.x.
-
-Example Applications:
- - [Example of how to to use the ArcGIS API for JavaScript in an Angular CLI app](https://github.com/tomwayson/esri-angular-cli-example)
- - [Esri-playground: Angular 2 & Esri 4](https://github.com/jwasilgeo/angular2-esri-playground)
- - [Example app using the ArcGIS API for JavaScript v3 in an Angular2 app](https://github.com/tomwayson/angular2-esri-example)
- - [An example mapping application using ArcGIS API for JavaScript v4 ](https://github.com/kgs916/ng2cli-esri4)
-
-### Ember
-
-[ember-cli-amd](https://github.com/Esri/ember-cli-amd) is an [EmberCLI](https://ember-cli.com/) addon for using AMD libraries that helps you load modules from the ArcGIS API for JavaScript (either 3.x or 4.x) in an Ember application.
-
-Example Applications:
-- [ArcGIS Open Data](http://opendata.arcgis.com/) is built using ember-cli-amd
-
-### React
-TODO
+Below are links to tools that will help you use the ArcGIS API for JavaScript in applications built with some of the more popular JavaScript frameworks.
+- [Using the ArcGIS API for JavaScript in Angular Applications](./angular/)
+- [Using the ArcGIS API for JavaScript in Angular 1 Applications](./angular-1/)
+- [Using the ArcGIS API for JavaScript in Ember Applications](./ember/)
+- [Using the ArcGIS API for JavaScript in React Applications](./react/)
 
 [ArcGIS API for JavaScript]:https://developers.arcgis.com/javascript/
 [Angular]:https://angular.io/

--- a/frameworks/angular-1/README.md
+++ b/frameworks/angular-1/README.md
@@ -1,0 +1,26 @@
+# Using the ArcGIS API for JavaScript in Angular 1 Applications
+
+Below are links to tools that will help you use the [ArcGIS API for JavaScript] in applications built with [Angular 1], as well as examples of how to use those tools. Also see [using the ArcGIS API for JavaScript with Angular (2 and above)](../angular).
+
+## Reusable Libraries
+### [angular-esri-map](https://github.com/Esri/angular-esri-map)
+A library of reusable directives and services to help you use Esri maps and data in your Angular 1 applications
+<br />[Documentation](http://esri.github.io/angular-esri-map/docs/#/api) | [Examples](http://esri.github.io/angular-esri-map/)
+
+## Example Applications
+### [angular-parcel-map](https://github.com/tomwayson/angular-parcel-map)
+A simple example of how to roll your own AngularJS directive to show an Esri map for a focused workflow.
+<br/> [View it live](http://tomwayson.github.io/angular-parcel-map/)
+
+### [ionic-esri-map](https://github.com/jwasilgeo/ionic-esri-map)
+Ionic app demonstrating how to use the Esri ArcGIS API for JavaScript
+
+## Additional Resources
+ - [Angular 1 Widgets Sample](https://developers.arcgis.com/javascript/latest/sample-code/widgets-frameworks-angular/index.html)
+ - [Using the ArcGIS API for JavaScript with Angular (2 and above)](../angular)
+ - [Working with Frameworks](../)
+ - [Awesome ArcGIS: Angular ](https://github.com/hhkaos/awesome-arcgis/tree/master/front-end/technologies/angular)
+ - [Angular 1]
+
+[ArcGIS API for JavaScript]:https://developers.arcgis.com/javascript/
+[Angular 1]:https://angularjs.org/

--- a/frameworks/angular/README.md
+++ b/frameworks/angular/README.md
@@ -1,0 +1,39 @@
+# Using the ArcGIS API for JavaScript in Angular Applications
+
+Below are links to tools that will help you use the [ArcGIS API for JavaScript] in applications built with [Angular] (2 and above), as well as examples of how to use those tools. Also see [using the ArcGIS API for JavaScript with Angular 1](../angular-1).
+
+## Reusable Libraries
+
+### [angular2-esri-loader](https://github.com/tomwayson/angular2-esri-loader)
+An Angular service to help you load modules from the ArcGIS API for JavaScript (either 3.x or 4.x) using the [esri-loader](https://github.com/tomwayson/esri-loader) library
+
+###  [angular2-esri4-components](https://github.com/kgs916/angular2-esri4-components)
+A set of reusable Angular components to work with ArcGIS API for JavaScript v4.x
+
+## Example Applications
+
+###  [esri-angular-cli-example](https://github.com/tomwayson/esri-angular-cli-example)
+Example of how to to use the ArcGIS API for JavaScript in an [Angular CLI] app
+<br />[View it live](https://tomwayson.github.io/esri-angular-cli-example/home)
+
+### [ionic2-esri-map](https://github.com/andygup/ionic2-esri-map)
+Prototype app demonstrating how to use Ionic2 with the ArcGIS API for JavaScript
+
+### [angular2-esri-playground](https://github.com/jwasilgeo/angular2-esri-playground)
+Esri-playground: Angular 2 & Esri 4 using [SystemJS](https://github.com/systemjs/systemjs) via [esri-system-js]
+<br />[View it live](http://jwasilgeo.github.io/angular2-esri-playground/)
+
+### [angular2-esri-example](https://github.com/tomwayson/angular2-esri-example)
+Example app using the ArcGIS API for JavaScript v3 in an Angular2 app
+<br />[View it live](http://tomwayson.github.io/angular2-esri-example/)
+
+## Additional Resources
+- [Using the ArcGIS API for JavaScript with Angular 1](../angular-1)
+- [Using the ArcGIS API for JavaScript with Frameworks](../)
+- [Awesome ArcGIS: Angular ](https://github.com/hhkaos/awesome-arcgis/tree/master/front-end/technologies/angular)
+- [Angular]
+
+[ArcGIS API for JavaScript]:https://developers.arcgis.com/javascript/
+[Angular]:https://angular.io/
+[Angular CLI]:https://github.com/angular/angular-cli
+[esri-system-js]:https://github.com/Esri/esri-system-js

--- a/frameworks/ember/README.md
+++ b/frameworks/ember/README.md
@@ -1,0 +1,21 @@
+# Using the ArcGIS API for JavaScript in Ember Applications
+
+Below are links to tools that will help you use the [ArcGIS API for JavaScript] in applications built with [Ember], as well as examples of how to use those tools.
+
+## Reusable Libraries
+### [ember-cli-amd](https://github.com/Esri/ember-cli-amd)
+An [EmberCLI](https://ember-cli.com/) addon for using AMD libraries that helps you load modules from the ArcGIS API for JavaScript (either 3.x or 4.x) in an Ember application.
+<br />[Blog post](http://odoe.net/blog/ember-with-arcgis-api-for-javascript/) | [Video](https://www.youtube.com/watch?v=9wbGhr6wdwE)
+
+## Example Applications
+
+### [esrijs4-vm-ember](https://github.com/odoe/esrijs4-vm-ember)
+Using ErsiJS 4.0 View Models with Ember
+
+## Additional Resources
+ - [Working with Frameworks](../)
+ - [Awesome ArcGIS: Ember ](https://github.com/hhkaos/awesome-arcgis/tree/master/front-end/technologies/ember)
+ - [Ember]
+
+[ArcGIS API for JavaScript]:https://developers.arcgis.com/javascript/
+[Ember]:http://emberjs.com/

--- a/frameworks/react/README.md
+++ b/frameworks/react/README.md
@@ -1,0 +1,35 @@
+# Using the ArcGIS API for JavaScript in React Applications
+
+Below are links to tools that will help you use the [ArcGIS API for JavaScript] in applications built with [React], as well as examples of how to use those tools.
+
+## Reusable Libraries
+
+### [esri-loader](https://github.com/tomwayson/esri-loader)
+A tiny library to help load ArcGIS API for JavaScript modules in non-Dojo applications (not specific to React)
+
+### [arcgis-react-redux-legend](https://github.com/davetimmins/arcgis-react-redux-legend)
+Legend control for ArcGIS JS v4 using React and Redux
+<br /> [View it live](https://davetimmins.com/arcgis-react-redux-legend/)
+
+## Example Applications
+
+### [esri-redux](https://github.com/Robert-W/esri-redux)
+Simple boilerplate demonstrating how to setup a project using React, Redux, Flow, and the Esri JavaScript API.
+<br /> [View it live](https://robert-w.github.io/esri-redux/)
+
+###  [esri-react-router-example](https://github.com/tomwayson/esri-react-router-example/)
+Example of how to lazy load the ArcGIS API for JavaScript in a react-router application
+<br /> [View it live](https://tomwayson.github.io/esri-react-router-example)
+
+### [create-react-app-esri-loader]( https://github.com/davetimmins/create-react-app-esri-loader/)
+Create React apps with no build configuration. Extended to add the ArcGIS JS API via esri-loader
+<br /> [View it live](https://davetimmins.com/create-react-app-esri-loader/)
+
+## Additional Resources
+- [React Widgets Sample](https://developers.arcgis.com/javascript/latest/sample-code/widgets-frameworks-react/index.html)
+- [Using the ArcGIS API for JavaScript with Frameworks](../)
+- [Awesome ArcGIS: React ](https://github.com/hhkaos/awesome-arcgis/tree/master/front-end/technologies/react)
+- [React]
+
+[ArcGIS API for JavaScript]:https://developers.arcgis.com/javascript/
+[React]:https://facebook.github.io/react/


### PR DESCRIPTION
First pass at a set of pages to link out to tools and examples of how to use the ArcGIS API for JavaScript with various frameworks. These pages are meant to compliment the framework examples in the [samples pages](https://developers.arcgis.com/javascript/latest/sample-code/index.html). The examples linked to here show how to use the ArcGIS API in applications that use the conventions and tooling typical of each framework (something we can't do in the sample pages).

You can view this live here:

https://github.com/tomwayson/jsapi-resources/tree/frameworks/frameworks
