### PR TITLE
mention additional resources in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,15 @@
-If you're asking for assistance please utilize the resources below.
+Esri welcomes contributions from anyone and everyone. Please see our
+[guidelines for contributing](https://github.com/esri/contributing).
+
+# Contributing to [ArcGIS API for Javascript](http://js.arcgis.com)
+
+There are several ways you can ask for assistance or provide feedback on the [ArcGIS API for Javascript](http://js.arcgis.com) from [Esri](https://www.esri.com/).
 
 * Contact [Esri Tech Support](https://support.esri.com/contact-tech-support)
-* Ask the Esri community on [GeoNet](https://geonet.esri.com/community/developers/web-developers/arcgis-api-for-javascript).
+* Ask the Esri community on [GeoNet](https://geonet.esri.com/community/developers/web-developers/arcgis-api-for-javascript)
 
-Additional information can be found in Esri's generic [guidelines for contributing](https://github.com/esri/contributing).
+# Contributing to this repo
+
+__NOTE__: The two arcgis-js-api.d.ts files are automatically created from source code, so no need to create pull requests for these generated files. However, feel free to report issues related to these files and we'll see if changes can be incorporated into our source code, and the next update of these generated files.
+
+For anything else in this repo, feel free to report issues and pull requests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+If you're asking for assistance please utilize the resources below.
+
+* Contact [Esri Tech Support](https://support.esri.com/contact-tech-support)
+* Ask the Esri community on [GeoNet](https://geonet.esri.com/community/developers/web-developers/arcgis-api-for-javascript).
+
+Additional information can be found in Esri's generic [guidelines for contributing](https://github.com/esri/contributing).

--- a/README.md
+++ b/README.md
@@ -26,10 +26,13 @@ Refer to the README files in each subdirectory of this repo for specific instruc
 * [TypeScript](http://www.typescriptlang.org/)
 
 ## Contributing
-Anyone and everyone is welcome to contribute. We accept pull requests. Feel free to:  
-* Report issues
-* Contribute code
-* Improve documentation
+
+Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](https://github.com/esri/contributing).
+
+We use issues and pull requests to address problems found in the [ArcGIS API for Javascript](http://js.arcgis.com/) here.  If you're asking for help please utilize the supplementary resources below.
+
+* Contact [Esri Tech Support](https://support.esri.com/contact-tech-support)
+* Ask the Esri community on [GeoNet](https://geonet.esri.com/community/developers/web-developers/arcgis-api-for-javascript).
 
 ## Licensing
 Copyright 2017 Esri

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Refer to the README files in each subdirectory of this repo for specific instruc
 
 ## Contributing
 
-Please see our [guidelines for contributing](contributing).
+Please see our [guidelines for contributing](CONTRIBUTING.md).
 
 ## Licensing
 Copyright 2017 Esri

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ A collection of resources for developers using the [ArcGIS API for JavaScript](h
 **OAuth**
 * [HTML for handling callbacks](./oauth/README.md)
 
-## Instructions  
-Refer to the README files in each subdirectory of this repo for specific instructions on how to use a particular resource.  
+## Instructions
+Refer to the README files in each subdirectory of this repo for specific instructions on how to use a particular resource.
 
 ## Resources
 * [ArcGIS API for JavaScript](https://js.arcgis.com)
@@ -27,12 +27,7 @@ Refer to the README files in each subdirectory of this repo for specific instruc
 
 ## Contributing
 
-Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](https://github.com/esri/contributing).
-
-We use issues and pull requests to address problems found in the [ArcGIS API for Javascript](http://js.arcgis.com/) here.  If you're asking for help please utilize the supplementary resources below.
-
-* Contact [Esri Tech Support](https://support.esri.com/contact-tech-support)
-* Ask the Esri community on [GeoNet](https://geonet.esri.com/community/developers/web-developers/arcgis-api-for-javascript).
+Please see our [guidelines for contributing](contributing).
 
 ## Licensing
 Copyright 2017 Esri


### PR DESCRIPTION
addresses #71 

i like the idea of putting the information directly in the README and just linking to Esri's generic boilerplate CONTRIBUTING doc.