### PR TITLE
TemplatePickerOptions.rows type

### DIFF
--- a/3.x/typescript/arcgis-js-api.d.ts
+++ b/3.x/typescript/arcgis-js-api.d.ts
@@ -2153,7 +2153,7 @@ declare module "esri" {
   }
   export interface TemplatePickerOptions {
     /** Number of visible columns. */
-    columns?: number;
+    columns?: number | string;
     /** Defines the text to be displayed when the template picker does not have any templates to display. */
     emptyMessage?: string;
     /** Array of input feature layers. */

--- a/3.x/typescript/arcgis-js-api.d.ts
+++ b/3.x/typescript/arcgis-js-api.d.ts
@@ -2165,7 +2165,7 @@ declare module "esri" {
     /** Length of label description. */
     maxLabelLength?: number;
     /** Number of visible rows. */
-    rows?: number;
+    rows?: number | string;
     /** Tooltip content contains the template name and description. */
     showTooltip?: boolean;
     /** HTML style attributes for the widget. */


### PR DESCRIPTION
3.x/typescript/arcgis-js-api.d.ts: TemplatePickerOptions.rows and .columns need to accept a string, because "auto" is an allowed value (see [https://developers.arcgis.com/javascript/3/jsapi/templatepicker-amd.html#templatepicker1](https://developers.arcgis.com/javascript/3/jsapi/templatepicker-amd.html#templatepicker1))