### PR TITLE
fixes node-sass related build issue

### DIFF
--- a/4.x/webpack/demo/package.json
+++ b/4.x/webpack/demo/package.json
@@ -3,30 +3,30 @@
   "version": "0.0.1",
   "devDependencies": {
     "@theintern/istanbul-loader": "^1.0.0-beta.2",
-    "@types/arcgis-js-api": "^4.7.0",
-    "@types/sinon": "^4.3.1",
+    "@types/arcgis-js-api": "^4.8.1",
+    "@types/sinon": "^5.0.1",
     "clean-webpack-plugin": "^0.1.19",
-    "copy-webpack-plugin": "4.5.1",
-    "css-loader": "^0.28.11",
+    "copy-webpack-plugin": "4.5.2",
+    "css-loader": "^1.0.0",
     "html-loader": "^0.5.5",
-    "html-webpack-plugin": "^3.1.0",
-    "mini-css-extract-plugin": "^0.4.0",
-    "node-sass": "4.8.1",
-    "prettier": "^1.12.1",
+    "html-webpack-plugin": "^3.2.0",
+    "mini-css-extract-plugin": "^0.4.2",
+    "node-sass": "4.9.3",
+    "prettier": "^1.14.2",
     "resolve-url-loader": "^2.3.0",
-    "sass-loader": "^6.0.7",
-    "style-loader": "0.20.3",
-    "ts-loader": "^4.1.0",
-    "tslib": "^1.9.1",
-    "tslint": "^5.9.1",
-    "tslint-config-prettier": "^1.12.0",
-    "tslint-eslint-rules": "^5.1.0",
+    "sass-loader": "^7.1.0",
+    "style-loader": "0.23.0",
+    "ts-loader": "^4.5.0",
+    "tslib": "^1.9.3",
+    "tslint": "^5.11.0",
+    "tslint-config-prettier": "^1.15.0",
+    "tslint-eslint-rules": "^5.4.0",
     "tslint-plugin-prettier": "^1.3.0",
-    "typescript": "^2.8.1",
-    "uglifyjs-webpack-plugin": "^1.2.7",
-    "webpack": "^4.8.0",
-    "webpack-cli": "^2.0.13",
-    "webpack-dev-server": "^3.1.1"
+    "typescript": "^3.0.1",
+    "uglifyjs-webpack-plugin": "^1.3.0",
+    "webpack": "^4.17.1",
+    "webpack-cli": "^3.1.0",
+    "webpack-dev-server": "^3.1.6"
   },
   "license": "Apache-2.0",
   "scripts": {
@@ -37,7 +37,7 @@
     "lint": "tslint --fix \"src/**/*.ts?(x)\""
   },
   "dependencies": {
-    "@arcgis/webpack-plugin": "^4.8.0"
+    "@arcgis/webpack-plugin": "^4.8.2"
   },
   "arcgis": {
     "type": "jsapi"


### PR DESCRIPTION
Updated dependency versions to fix node-sass related build issue, described below.

I am reporting an issue with

- [ ] TypeScript definitions
- [x] another resource in this repository

OS: Windows 10

Running NPM install results in an error related to node-sass.

First, it tries to download a file from Github, which does not exist.

```console
> node-sass@4.8.1 install C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass
> node scripts/install.js

Downloading binary from https://github.com/sass/node-sass/releases/download/v4.8.1/win32-x64-64_binding.node
Cannot download "https://github.com/sass/node-sass/releases/download/v4.8.1/win32-x64-64_binding.node":

HTTP error 404 Not Found
```
Then it tries to build the file that it couldn't download, but fails because I don't have Windows SDK version 8.1 installed.

```console
> node-sass@4.8.1 postinstall C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass
> node scripts/build.js

Building: C:\Program Files\nodejs\node.exe C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-gyp\bin\node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
gyp info it worked if it ends with ok
gyp verb cli [ 'C:\\Program Files\\nodejs\\node.exe',
gyp verb cli   'C:\\Users\\jacobsj\\Documents\\GitHub\\jsapi-resources\\4.x\\webpack\\demo\\node_modules\\node-gyp\\bin\\node-gyp.js',
gyp verb cli   'rebuild',
gyp verb cli   '--verbose',
gyp verb cli   '--libsass_ext=',
gyp verb cli   '--libsass_cflags=',
gyp verb cli   '--libsass_ldflags=',
gyp verb cli   '--libsass_library=' ]
gyp info using node-gyp@3.8.0
gyp info using node@10.9.0 | win32 | x64
gyp verb command rebuild []
gyp verb command clean []
gyp verb clean removing "build" directory
gyp verb command configure []
gyp verb check python checking for Python executable "C:\Users\jacobsj\.windows-build-tools\python27\python.exe" in the PATH
gyp verb `which` succeeded C:\Users\jacobsj\.windows-build-tools\python27\python.exe C:\Users\jacobsj\.windows-build-tools\python27\python.exe
gyp verb check python version `C:\Users\jacobsj\.windows-build-tools\python27\python.exe -c "import sys; print "2.7.14
gyp verb check python version .%s.%s" % sys.version_info[:3];"` returned: %j
gyp verb get node dir no --target version specified, falling back to host node version: 10.9.0
gyp verb command install [ '10.9.0' ]
gyp verb install input version string "10.9.0"
gyp verb install installing version: 10.9.0
gyp verb install --ensure was passed, so won't reinstall if already installed
gyp verb install version is already installed, need to check "installVersion"
gyp verb got "installVersion" 9
gyp verb needs "installVersion" 9
gyp verb install version is good
gyp verb get node dir target node version installed: 10.9.0
gyp verb build dir attempting to create "build" dir: C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build
gyp verb build dir "build" dir needed to be created? C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build
gyp verb build/config.gypi creating config file
gyp verb build/config.gypi writing out config file: C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\config.gypi
gyp verb config.gypi checking for gypi file: C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\config.gypi
gyp verb common.gypi checking for gypi file: C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\common.gypi
gyp verb gyp gyp format was not specified; forcing "msvs"
gyp info spawn C:\Users\jacobsj\.windows-build-tools\python27\python.exe
gyp info spawn args [ 'C:\\Users\\jacobsj\\Documents\\GitHub\\jsapi-resources\\4.x\\webpack\\demo\\node_modules\\node-gyp\\gyp\\gyp_main.py',
gyp info spawn args   'binding.gyp',
gyp info spawn args   '-f',
gyp info spawn args   'msvs',
gyp info spawn args   '-G',
gyp info spawn args   'msvs_version=2015',
gyp info spawn args   '-I',
gyp info spawn args   'C:\\Users\\jacobsj\\Documents\\GitHub\\jsapi-resources\\4.x\\webpack\\demo\\node_modules\\node-sass\\build\\config.gypi',
gyp info spawn args   '-I',
gyp info spawn args   'C:\\Users\\jacobsj\\Documents\\GitHub\\jsapi-resources\\4.x\\webpack\\demo\\node_modules\\node-gyp\\addon.gypi',
gyp info spawn args   '-I',
gyp info spawn args   'C:\\Users\\jacobsj\\.node-gyp\\10.9.0\\include\\node\\common.gypi',
gyp info spawn args   '-Dlibrary=shared_library',
gyp info spawn args   '-Dvisibility=default',
gyp info spawn args   '-Dnode_root_dir=C:\\Users\\jacobsj\\.node-gyp\\10.9.0',
gyp info spawn args   '-Dnode_gyp_dir=C:\\Users\\jacobsj\\Documents\\GitHub\\jsapi-resources\\4.x\\webpack\\demo\\node_modules\\node-gyp',
gyp info spawn args   '-Dnode_lib_file=C:\\Users\\jacobsj\\.node-gyp\\10.9.0\\<(target_arch)\\node.lib',
gyp info spawn args   '-Dmodule_root_dir=C:\\Users\\jacobsj\\Documents\\GitHub\\jsapi-resources\\4.x\\webpack\\demo\\node_modules\\node-sass',
gyp info spawn args   '-Dnode_engine=v8',
gyp info spawn args   '--depth=.',
gyp info spawn args   '--no-parallel',
gyp info spawn args   '--generator-output',
gyp info spawn args   'C:\\Users\\jacobsj\\Documents\\GitHub\\jsapi-resources\\4.x\\webpack\\demo\\node_modules\\node-sass\\build',
gyp info spawn args   '-Goutput_dir=.' ]
gyp verb command build []
gyp verb build type Release
gyp verb architecture x64
gyp verb node dev dir C:\Users\jacobsj\.node-gyp\10.9.0
gyp verb found first Solution file build/binding.sln
gyp verb could not find "msbuild.exe" in PATH - finding location in registry
gyp info spawn C:\Program Files (x86)\MSBuild\14.0\bin\msbuild.exe
gyp info spawn args [ 'build/binding.sln',
gyp info spawn args   '/nologo',
gyp info spawn args   '/p:Configuration=Release;Platform=x64' ]
Building the projects in this solution one at a time. To enable parallel build, please add the "/m" switch.
Build started 8/27/2018 10:48:25 AM.
Project "C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\binding.sln" on node 1 (default targets).
ValidateSolutionConfiguration:
  Building solution configuration "Release|x64".
Project "C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\binding.sln" (1) is building "C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\binding.vcxproj.metaproj" (2) on node 1 (default ta
rgets).
Project "C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\binding.vcxproj.metaproj" (2) is building "C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\src\libsass.vcxproj" (3) on node 1 (de
fault targets).
C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Platforms\x64\PlatformToolsets\v140\Toolset.targets(36,5): error MSB8036: The Windows SDK version 8.1 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by righ
t-clicking the solution and selecting "Retarget solution". [C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\src\libsass.vcxproj]
Done Building Project "C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\src\libsass.vcxproj" (default targets) -- FAILED.

Done Building Project "C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\binding.vcxproj.metaproj" (default targets) -- FAILED.

Done Building Project "C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\binding.sln" (default targets) -- FAILED.

Build FAILED.

"C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\binding.sln" (default target) (1) ->
"C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\binding.vcxproj.metaproj" (default target) (2) ->
"C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\src\libsass.vcxproj" (default target) (3) ->
(Desktop_PlatformPrepareForBuild target) ->
  C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V140\Platforms\x64\PlatformToolsets\v140\Toolset.targets(36,5): error MSB8036: The Windows SDK version 8.1 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by ri
ght-clicking the solution and selecting "Retarget solution". [C:\Users\jacobsj\Documents\GitHub\jsapi-resources\4.x\webpack\demo\node_modules\node-sass\build\src\libsass.vcxproj]

    0 Warning(s)
    1 Error(s)
```