### PR TITLE
bower file - clone with https

### DIFF
--- a/3.x/bower/dojo/bower.json
+++ b/3.x/bower/dojo/bower.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "esri": "arcgis-js-api#3.26.1",
-    "dijit-themes": "git@github.com:dojo/dijit-themes.git#1.14.0"
+    "dijit-themes": "https://github.com/dojo/dijit-themes.git#1.14.0"
   },
   "resolutions": {
     "dojo": "v1.14.0/esri-3.26.0",


### PR DESCRIPTION
Using the HTTPS url instead of the `git@` is the only url structure that works for me, and AFAIK it's generally more compatible for more users.