### PR TITLE
TypeScript demo: update dojo app regex to work with more url scenarios

### DIFF
--- a/4.x/typescript/demo/index.html
+++ b/4.x/typescript/demo/index.html
@@ -15,7 +15,7 @@
     </style>
     <link rel="stylesheet" href="https://js.arcgis.com/4.11/esri/themes/light/main.css">
     <script>
-      var locationPath = location.pathname.replace(/\/[^\/]+$/, "");
+      var locationPath = location.pathname.replace(/\/[^/]*$/, "");
       window.dojoConfig = {
         packages: [
           {


### PR DESCRIPTION
This regex works better for me in cases that we're at the root (website.com) OR at a subdirectory (website.com/demo/). This is the regex used in https://dojotoolkit.org/documentation/tutorials/1.10/hello_dojo. 