### PR TITLE
Add dojo-util dev dependency

### DIFF
--- a/4.x/npm/demo/package.json
+++ b/4.x/npm/demo/package.json
@@ -13,6 +13,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
+    "dojo-util": "github:Esri/dojo-util#v1.14.2/esri-3.28.0",
     "grunt": "^1.0.4",
     "grunt-contrib-clean": "^2.0.0",
     "grunt-contrib-copy": "^1.0.0",


### PR DESCRIPTION
When upgrading from 4.13->4.15, ran into an issue with a missing dependency, dojo-util, that used to be a transitive dependency of arcgis-js-api.

According to https://developers.arcgis.com/javascript/latest/guide/using-npm/index.html#build-dojo

> When creating dojo builds, you will need to install the dojo utilities in your project.
> npm install --save-dev Esri/dojo-util#v1.14.2/esri-3.28.0

Build was able to successfully complete after installing dojo-util as a dev-dependency.
