### PR TITLE
Fixes a typo in the module definition for PlayerZoomBehaviors

### DIFF
--- a/3.x/typescript/arcgis-js-api.d.ts
+++ b/3.x/typescript/arcgis-js-api.d.ts
@@ -18206,7 +18206,7 @@ declare module "esri/workers/WorkerClient" {
   export = WorkerClient;
 }
 
-declare module "sri/dijit/geoenrichment/ReportPlayer/PlayerZoomBehaviors" {
+declare module "esri/dijit/geoenrichment/ReportPlayer/PlayerZoomBehaviors" {
   /** Enumerator of available zoom behavior options for the ReportPlayer. */
   class PlayerZoomBehaviors {
     /** The Report Player zooms in to fit a full page in the viewable area. */


### PR DESCRIPTION
The existing namespace is listed as "sri" rather than "esri".