### PR TITLE
fix #235, need loaders for assets

### DIFF
--- a/esm-samples/webpack/package-lock.json
+++ b/esm-samples/webpack/package-lock.json
@@ -5,12 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@arcgis/core": "^4.18.0-next.20201102"
+        "@arcgis/core": "^4.18.0"
       },
       "devDependencies": {
         "@arcgis/webpack-plugin": "4.18.0-next.20201029",
         "clean-webpack-plugin": "^3.0.0",
         "css-loader": "^5.0.0",
+        "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.0.0-alpha.7",
         "mini-css-extract-plugin": "^1.2.1",
         "moment-locales-webpack-plugin": "^1.2.0",
@@ -22,27 +23,16 @@
       }
     },
     "node_modules/@arcgis/core": {
-      "version": "4.18.0-next.20201102",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.18.0-next.20201102.tgz",
-      "integrity": "sha512-y1Z5GwG3tC/d3pKq9F7bq3lug21gmlaN9ieOBk97lrABYqFnLLO2eWcOK7iZxy6RYbopB2Ghq3bkFjXwwM6GUQ==",
-      "license": "SEE LICENSE IN copyright.txt",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.18.0.tgz",
+      "integrity": "sha512-YhZRcexbEhOX9L+svCor3Am/SiwW5XNOrtJoEO3/esE8Bs+rFWjR9EsOgC782H4MU5XqYoYf/rhxZsRF8zhoAA==",
       "dependencies": {
-        "@esri/arcgis-html-sanitizer": "~2.4.2",
+        "@esri/arcgis-html-sanitizer": "~2.5.0",
         "@esri/calcite-colors": "~5.0.0",
         "@popperjs/core": "~2.4.4",
-        "intersection-observer": "~0.11.0",
-        "moment": "~2.24.0",
-        "resize-observer-polyfill": "~1.5.1",
-        "sortablejs": "~1.10.2",
-        "whatwg-fetch": "~3.4.1"
-      }
-    },
-    "node_modules/@arcgis/core/node_modules/moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
-      "engines": {
-        "node": "*"
+        "focus-trap": "~6.2.2",
+        "moment": "~2.29.1",
+        "sortablejs": "~1.10.2"
       }
     },
     "node_modules/@arcgis/webpack-plugin": {
@@ -66,9 +56,9 @@
       }
     },
     "node_modules/@esri/arcgis-html-sanitizer": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.4.2.tgz",
-      "integrity": "sha512-Xc0opYVfZ1dtdn6fBAuJa0Y8XXEFm3NZLU9ZHTNzV49coKQZXcgyQ926z9WOX3o7/Ta6gg+kTLgfz8SWWuQrFw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.5.0.tgz",
+      "integrity": "sha512-axq4dGwm3bjY/iR1DoPxrnJOt2SKXD0Cy1QYihK4yZx25CEDpfdSUBE71oz77BSYFz+KQZvh6A3xxOgLnVEoWA==",
       "dependencies": {
         "lodash.isplainobject": "^4.0.6",
         "xss": "^1.0.8"
@@ -2994,6 +2984,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/focus-trap": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.3.tgz",
+      "integrity": "sha512-87orNbj6UqKEDxmqDfYBDLBbqgxNIA5cXUBvHCt7dZ8/L0KTuzkjKoI0xXHU+5TyI9fImqfOJyvEkXYmZeClZA==",
+      "dependencies": {
+        "tabbable": "^5.1.4"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
@@ -3766,11 +3764,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/intersection-observer": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.11.0.tgz",
-      "integrity": "sha512-KZArj2QVnmdud9zTpKf279m2bbGfG+4/kn16UU0NL3pTVl52ZHiJ9IRNSsnn6jaHrL9EGLFM5eWjTx2fz/+zoQ=="
     },
     "node_modules/ip": {
       "version": "1.1.5",
@@ -4652,8 +4645,6 @@
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "dev": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -6135,11 +6126,6 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
     "node_modules/resolve": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
@@ -7337,6 +7323,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.5.tgz",
+      "integrity": "sha512-oVAPrWgLLqrbvQE8XqcU7CVBq6SQbaIbHkhOca3u7/jzuQvyZycrUKPCGr04qpEIUslmUlULbSeN+m3QrKEykA=="
     },
     "node_modules/table-layout": {
       "version": "1.0.1",
@@ -8554,11 +8545,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
-    },
     "node_modules/which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
@@ -8834,25 +8820,16 @@
   },
   "dependencies": {
     "@arcgis/core": {
-      "version": "4.18.0-next.20201102",
-      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.18.0-next.20201102.tgz",
-      "integrity": "sha512-y1Z5GwG3tC/d3pKq9F7bq3lug21gmlaN9ieOBk97lrABYqFnLLO2eWcOK7iZxy6RYbopB2Ghq3bkFjXwwM6GUQ==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@arcgis/core/-/core-4.18.0.tgz",
+      "integrity": "sha512-YhZRcexbEhOX9L+svCor3Am/SiwW5XNOrtJoEO3/esE8Bs+rFWjR9EsOgC782H4MU5XqYoYf/rhxZsRF8zhoAA==",
       "requires": {
-        "@esri/arcgis-html-sanitizer": "~2.4.2",
+        "@esri/arcgis-html-sanitizer": "~2.5.0",
         "@esri/calcite-colors": "~5.0.0",
         "@popperjs/core": "~2.4.4",
-        "intersection-observer": "~0.11.0",
-        "moment": "~2.24.0",
-        "resize-observer-polyfill": "~1.5.1",
-        "sortablejs": "~1.10.2",
-        "whatwg-fetch": "~3.4.1"
-      },
-      "dependencies": {
-        "moment": {
-          "version": "2.24.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-        }
+        "focus-trap": "~6.2.2",
+        "moment": "~2.29.1",
+        "sortablejs": "~1.10.2"
       }
     },
     "@arcgis/webpack-plugin": {
@@ -8869,9 +8846,9 @@
       }
     },
     "@esri/arcgis-html-sanitizer": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.4.2.tgz",
-      "integrity": "sha512-Xc0opYVfZ1dtdn6fBAuJa0Y8XXEFm3NZLU9ZHTNzV49coKQZXcgyQ926z9WOX3o7/Ta6gg+kTLgfz8SWWuQrFw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@esri/arcgis-html-sanitizer/-/arcgis-html-sanitizer-2.5.0.tgz",
+      "integrity": "sha512-axq4dGwm3bjY/iR1DoPxrnJOt2SKXD0Cy1QYihK4yZx25CEDpfdSUBE71oz77BSYFz+KQZvh6A3xxOgLnVEoWA==",
       "requires": {
         "lodash.isplainobject": "^4.0.6",
         "xss": "^1.0.8"
@@ -11269,6 +11246,14 @@
         "path-exists": "^4.0.0"
       }
     },
+    "focus-trap": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.3.tgz",
+      "integrity": "sha512-87orNbj6UqKEDxmqDfYBDLBbqgxNIA5cXUBvHCt7dZ8/L0KTuzkjKoI0xXHU+5TyI9fImqfOJyvEkXYmZeClZA==",
+      "requires": {
+        "tabbable": "^5.1.4"
+      }
+    },
     "follow-redirects": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
@@ -11879,11 +11864,6 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
       "dev": true
-    },
-    "intersection-observer": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.11.0.tgz",
-      "integrity": "sha512-KZArj2QVnmdud9zTpKf279m2bbGfG+4/kn16UU0NL3pTVl52ZHiJ9IRNSsnn6jaHrL9EGLFM5eWjTx2fz/+zoQ=="
     },
     "ip": {
       "version": "1.1.5",
@@ -12554,9 +12534,7 @@
     "moment": {
       "version": "2.29.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "dev": true,
-      "peer": true
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-locales-webpack-plugin": {
       "version": "1.2.0",
@@ -13716,11 +13694,6 @@
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
     "resolve": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.18.1.tgz",
@@ -14687,6 +14660,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "tabbable": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.5.tgz",
+      "integrity": "sha512-oVAPrWgLLqrbvQE8XqcU7CVBq6SQbaIbHkhOca3u7/jzuQvyZycrUKPCGr04qpEIUslmUlULbSeN+m3QrKEykA=="
+    },
     "table-layout": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
@@ -15616,11 +15594,6 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "dev": true
-    },
-    "whatwg-fetch": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz",
-      "integrity": "sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ=="
     },
     "which": {
       "version": "1.3.1",

--- a/esm-samples/webpack/package.json
+++ b/esm-samples/webpack/package.json
@@ -7,6 +7,7 @@
     "@arcgis/webpack-plugin": "4.18.0-next.20201029",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^5.0.0",
+    "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.0.0-alpha.7",
     "mini-css-extract-plugin": "^1.2.1",
     "moment-locales-webpack-plugin": "^1.2.0",

--- a/esm-samples/webpack/webpack.config.js
+++ b/esm-samples/webpack/webpack.config.js
@@ -23,6 +23,14 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.(ttf|eot|svg|png|jpg|gif|ico|wsv|otf|woff(2)?)(\?[a-z0-9]+)?$/,
+        use: [
+          {
+            loader: 'file-loader'
+          }
+        ]
+      },
+      {
         test: /\.css$/,
         use: [
           MiniCssExtractPlugin.loader,


### PR DESCRIPTION
This PR adds an additional `file-loader` rule for css assets.

This only seems to be required for Windows, as the `@arcgis/webpack-plugin` handles most of these, but could be some conflict in nested deps.