### PR TITLE
esm-samples - add info to README about config.assetsPath

### DIFF
--- a/esm-samples/README.md
+++ b/esm-samples/README.md
@@ -28,7 +28,7 @@ const view = new MapView({
 
 ## Copy assets
 
-Make sure to copy the API’s assets, which includes styles, images, fonts, and localization files from the `@arcgis/core/assets` folder to your build directory. A simple way to accomplish this is to configure an NPM script that runs during your build process. For example, use npm to install `ncp` and configure a script in package.json to copy the assets folder. Here’s a React example:
+Make sure to copy the API’s assets, which includes styles, images, fonts, and localization files from the `@arcgis/core/assets` folder to your build directory. A simple way to accomplish this is to configure an NPM script that runs during your build process. For example, use npm to install `ncp` and configure a script in `package.json` to copy the assets folder. Here’s a React example:
 
 ```js
 
@@ -37,9 +37,18 @@ Make sure to copy the API’s assets, which includes styles, images, fonts, and 
     "script": {
         "start": "npm run copy && react-scripts start",
         "build": "npm run copy && react-scripts build",
-        "copy": "ncp ./node_modules/@arcgis/core/assets ./public/assets"
+        "copy": "ncp ./node_modules/@arcgis/core/assets ./assets"
     }
 }
+```
+
+When assets are loaded from paths that are different than the default location (e.g. `./assets`), set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) to insure the paths are correctly resolved. Examples include when using multiple routes in Angular, or when you need to relocate the assets because of project requirements.
+
+```js
+import config from '@arcgis/core/config.js';
+
+// Assets have been moved from the default location
+config.assetsPath = '/public/assets';
 ```
 
 ## Configure CSS


### PR DESCRIPTION
Add info on when to use config.assetsPath. I also opened an issue for the SDK at 4.19. I figured having this info in multiple places is the best approach since we've gotten a number of questions about it.