### PR TITLE
Update ESM samples to set assetsPath

### DIFF
--- a/esm-samples/README.md
+++ b/esm-samples/README.md
@@ -42,7 +42,7 @@ Copy the API’s assets, which includes styles, images, fonts, and localization 
 }
 ```
 
-Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) to the same path where you copied the assets to insure they are correctly resolved, for example:
+Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) to insure the assets are correctly resolved, for example:
 
 ```js
 import esriConfig from '@arcgis/core/config.js';

--- a/esm-samples/README.md
+++ b/esm-samples/README.md
@@ -26,9 +26,9 @@ const view = new MapView({
 });
 ```
 
-## Copy assets
+## Copy assets and set assetsPath
 
-Make sure to copy the API’s assets, which includes styles, images, fonts, and localization files from the `@arcgis/core/assets` folder to your build directory. A simple way to accomplish this is to configure an NPM script that runs during your build process. For example, use npm to install `ncp` and configure a script in `package.json` to copy the assets folder. Here’s a React example:
+Copy the API’s assets, which includes styles, images, fonts, and localization files from the `@arcgis/core/assets` folder to your build directory. A simple way to accomplish this is to configure an NPM script that runs during your build process. For example, use npm to install `ncp` and configure a script in `package.json` to copy the assets folder. Here’s a React example:
 
 ```js
 
@@ -42,13 +42,12 @@ Make sure to copy the API’s assets, which includes styles, images, fonts, and 
 }
 ```
 
-When assets are loaded from paths that are different than the default location (e.g. `./assets`), set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) to insure the paths are correctly resolved. Examples include when using multiple routes in Angular, or when you need to relocate the assets because of project requirements.
+Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) to the same path where you copied the assets to insure they are correctly resolved, for example:
 
 ```js
-import config from '@arcgis/core/config.js';
+import esriConfig from '@arcgis/core/config.js';
 
-// Assets have been moved from the default location
-config.assetsPath = '/public/assets';
+esriConfig.assetsPath = './assets';
 ```
 
 ## Configure CSS

--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -51,7 +51,7 @@ import esriConfig from "@arcgis/core/config.js";
   . . .
 
   ngOnInit(): any {
-    esriConfig.assetsPath = "/assets"; //assuming assets are in /assets
+    esriConfig.assetsPath = "./assets"; //assuming assets are in /assets
   }
 ```
 

--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -43,15 +43,15 @@ To use the CSS at a component-level, set a CSS link in `index.html`:
   <link rel="stylesheet" href="assets/esri/themes/dark/main.css">
 ```
 
-**Step 4** Working with Routes - when building routes, set the base url for the `/assets` folder. Development and deployment will require setting different urls. 
+**Step 4** Set the base url for the assets folder so they are correctly resolved. 
 
 ```javascript
-import config from "@arcgis/core/config.js";
+import esriConfig from "@arcgis/core/config.js";
 
   . . .
 
   ngOnInit(): any {
-    config.assetsPath = "/assets"; //assuming assets are in /assets
+    esriConfig.assetsPath = "/assets"; //assuming assets are in /assets
   }
 ```
 

--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -43,7 +43,7 @@ To use the CSS at a component-level, set a CSS link in `index.html`:
   <link rel="stylesheet" href="assets/esri/themes/dark/main.css">
 ```
 
-**Step 4** Set the base url for the assets folder so they are correctly resolved. 
+**Step 4** Set the base url for the assets folder so they are correctly resolved. When working with routes, use a path that is not relative to the page's path, e.g. `/assets`.
 
 ```javascript
 import esriConfig from "@arcgis/core/config.js";
@@ -51,7 +51,7 @@ import esriConfig from "@arcgis/core/config.js";
   . . .
 
   ngOnInit(): any {
-    esriConfig.assetsPath = "./assets"; //assuming assets are in /assets
+    esriConfig.assetsPath = "/assets"; //assuming assets are in /assets
   }
 ```
 

--- a/esm-samples/jsapi-angular-cli/src/app/app.component.ts
+++ b/esm-samples/jsapi-angular-cli/src/app/app.component.ts
@@ -74,7 +74,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
     // Required: Set this property to insure assets resolve correctly.
     // IMPORTANT: the directory path may be different between your product app and your dev app
-    esriConfig.assetsPath = '/assets';
+    esriConfig.assetsPath = './assets';
 
     this.zone.runOutsideAngular(() => {
       // Initialize MapView and return an instance of MapView

--- a/esm-samples/jsapi-angular-cli/src/app/app.component.ts
+++ b/esm-samples/jsapi-angular-cli/src/app/app.component.ts
@@ -11,7 +11,7 @@ import WebMap from '@arcgis/core/WebMap';
 import MapView from '@arcgis/core/views/MapView';
 import Bookmarks from '@arcgis/core/widgets/Bookmarks';
 import Expand from '@arcgis/core/widgets/Expand';
-import config from '@arcgis/core/config.js';
+import esriConfig from '@arcgis/core/config.js';
 
 @Component({
   selector: 'app-root',
@@ -72,10 +72,9 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit(): any {
 
-    // Set this property when using routes in order to resolve the /assets correctly.
+    // Required: Set this property to insure assets resolve correctly.
     // IMPORTANT: the directory path may be different between your product app and your dev app
-    // config.assetsPath = "/assets";
-    config.assetsPath = 'assets/';
+    esriConfig.assetsPath = '/assets';
 
     this.zone.runOutsideAngular(() => {
       // Initialize MapView and return an instance of MapView

--- a/esm-samples/jsapi-angular-cli/src/app/app.component.ts
+++ b/esm-samples/jsapi-angular-cli/src/app/app.component.ts
@@ -73,8 +73,8 @@ export class AppComponent implements OnInit, OnDestroy {
   ngOnInit(): any {
 
     // Required: Set this property to insure assets resolve correctly.
-    // IMPORTANT: the directory path may be different between your product app and your dev app
-    esriConfig.assetsPath = './assets';
+    // IMPORTANT: the directory path may be different between your production app and your dev app
+    esriConfig.assetsPath = '/assets';
 
     this.zone.runOutsideAngular(() => {
       // Initialize MapView and return an instance of MapView

--- a/esm-samples/jsapi-create-react-app/README.md
+++ b/esm-samples/jsapi-create-react-app/README.md
@@ -13,6 +13,14 @@ Integrating React with [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/co
 }
 ```
 
+Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) so that the assets are correctly resolved, for example:
+
+```js
+import esriConfig from '@arcgis/core/config.js';
+
+esriConfig.assetsPath = './assets'; 
+```
+
 There were recent versions of `create-react-app` that would attempt to inject babel helpers into ArcGIS API for JavaScript code during the build, but would not copy the helper files. We were able to prevent this by letting the build only build for modern browsers.
 
 ```json

--- a/esm-samples/jsapi-create-react-app/src/App.js
+++ b/esm-samples/jsapi-create-react-app/src/App.js
@@ -3,10 +3,15 @@ import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
 import ArcGISMap from "@arcgis/core/Map";
 import DictionaryRenderer from "@arcgis/core/renderers/DictionaryRenderer";
 import MapView from "@arcgis/core/views/MapView";
+import esriConfig from '@arcgis/core/config.js';
 
 import "./App.css";
 
 function App() {
+
+  // Required: Set this property to insure assets resolve correctly.
+  esriConfig.assetsPath = './assets'; 
+
   const mapDiv = useRef(null);
 
   useEffect(() => {

--- a/esm-samples/jsapi-ember-cli/README.md
+++ b/esm-samples/jsapi-ember-cli/README.md
@@ -2,6 +2,14 @@
 
 This repo integrates [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) using [embroider](https://github.com/embroider-build/embroider).
 
+Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) so that the assets are correctly resolved, for example:
+
+```js
+import esriConfig from '@arcgis/core/config.js';
+
+esriConfig.assetsPath = './assets'; 
+```
+
 To prevent runtime errors in production builds make sure target browsers do not include IE 11.
 
 ```js

--- a/esm-samples/jsapi-ember-cli/app/components/map.js
+++ b/esm-samples/jsapi-ember-cli/app/components/map.js
@@ -4,9 +4,14 @@ import WebMap from '@arcgis/core/WebMap';
 import MapView from '@arcgis/core/views/MapView';
 import Bookmarks from '@arcgis/core/widgets/Bookmarks';
 import Expand from '@arcgis/core/widgets/Expand';
+import esriConfig from '@arcgis/core/config.js';
 
 export default class MapComponent extends Component {
   registerMapElement(element) {
+
+    // Required: Set this property to insure assets resolve correctly.
+    esriConfig.assetsPath = './assets';     
+
     const webmap = new WebMap({
       portalItem: {
         id: 'aa1d3f80270146208328cf66d022e09c',

--- a/esm-samples/jsapi-node/README.md
+++ b/esm-samples/jsapi-node/README.md
@@ -29,6 +29,14 @@ require("cross-fetch/polyfill");
 
 You can find native ESM samples in the [native-esm folder](./native-esm).
 
+Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) so that the assets are correctly resolved, for example:
+
+```js
+import esriConfig from '@arcgis/core/config.js';
+
+esriConfig.assetsPath = "node_modules/@arcgis/core/assets"; // relative to when running in root
+```
+
 ## IdentityManager
 
 You will also want to disable the [`IdentityManager`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#request) so it doesn't attempt to load DOM related JavaScript.

--- a/esm-samples/jsapi-node/src/projection.js
+++ b/esm-samples/jsapi-node/src/projection.js
@@ -2,6 +2,7 @@ import esriConfig from "@arcgis/core/config.js";
 import * as pe from "@arcgis/core/geometry/projection.js";
 import Point from "@arcgis/core/geometry/Point.js";
 
+// Required: Set this property to insure assets resolve correctly.
 esriConfig.assetsPath = "node_modules/@arcgis/core/assets"; // relative to when running in root
 
 pe.load()

--- a/esm-samples/jsapi-vue-cli/README.md
+++ b/esm-samples/jsapi-vue-cli/README.md
@@ -13,6 +13,14 @@ Integrating Vue with [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core
 }
 ```
 
+Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) so that the assets are correctly resolved, for example:
+
+```js
+import esriConfig from '@arcgis/core/config.js';
+
+esriConfig.assetsPath = './assets'; 
+```
+
 ---
 
 # vue-cli

--- a/esm-samples/jsapi-vue-cli/src/App.vue
+++ b/esm-samples/jsapi-vue-cli/src/App.vue
@@ -7,6 +7,7 @@ import WebMap from "@arcgis/core/WebMap";
 import MapView from "@arcgis/core/views/MapView";
 import Bookmarks from "@arcgis/core/widgets/Bookmarks";
 import Expand from "@arcgis/core/widgets/Expand";
+import esriConfig from '@arcgis/core/config.js';
 
 export default {
   name: 'App',
@@ -16,6 +17,9 @@ export default {
         id: "aa1d3f80270146208328cf66d022e09c",
       },
     });
+
+    // Set this property to insure assets resolve correctly.
+    esriConfig.assetsPath = './assets'; 
 
     const view = new MapView({
       container: this.$el,

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -1,3 +1,11 @@
 # ArcGIS API for JavaScript with rollup
 
 This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) esm modules with rollup.
+
+Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) so that the assets are correctly resolved, for example:
+
+```js
+import esriConfig from '@arcgis/core/config.js';
+
+esriConfig.assetsPath = './assets'; 
+```

--- a/esm-samples/rollup/src/main.js
+++ b/esm-samples/rollup/src/main.js
@@ -2,10 +2,15 @@ import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
 import ArcGISMap from '@arcgis/core/Map';
 import DictionaryRenderer from '@arcgis/core/renderers/DictionaryRenderer';
 import MapView from '@arcgis/core/views/MapView';
+import esriConfig from '@arcgis/core/config.js';
 
 /**
  * Initialize application
  */
+
+// Required: Set this property to insure assets resolve correctly.
+esriConfig.assetsPath = './assets'; 
+
 const map = new ArcGISMap({
   basemap: 'gray-vector'
 });

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -3,3 +3,11 @@
 This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) esm modules with webpack.
 
 This repo also uses the [`@arcgis/webpack-plugin@next`](https://www.npmjs.com/package/@arcgis/webpack-plugin) webpack plugin to copy assets and help to minimize your deployed application size. You can read the updated `@arcgis/webpack-plugin` documentation [here](https://github.com/Esri/arcgis-webpack-plugin/tree/update-for-esm).
+
+Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) so that the assets are correctly resolved, for example:
+
+```js
+import esriConfig from '@arcgis/core/config.js';
+
+esriConfig.assetsPath = './assets'; 
+```

--- a/esm-samples/webpack/src/index.js
+++ b/esm-samples/webpack/src/index.js
@@ -12,7 +12,7 @@ import Bookmarks from "@arcgis/core/widgets/Bookmarks";
 import Legend from "@arcgis/core/widgets/Legend";
 
 // Required: Set this property to insure assets resolve correctly.
-esriConfig.assetsPath = "./assets"; // relative to when running in root
+esriConfig.assetsPath = "./assets"; 
 
 const map = new WebMap({
   portalItem: {

--- a/esm-samples/webpack/src/index.js
+++ b/esm-samples/webpack/src/index.js
@@ -1,3 +1,5 @@
+import esriConfig from "@arcgis/core/config.js";
+
 import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
 
 import WebMap from "@arcgis/core/WebMap";
@@ -8,6 +10,9 @@ import DotDensityRenderer from "@arcgis/core/renderers/DotDensityRenderer";
 import Expand from "@arcgis/core/widgets/Expand";
 import Bookmarks from "@arcgis/core/widgets/Bookmarks";
 import Legend from "@arcgis/core/widgets/Legend";
+
+// Required: Set this property to insure assets resolve correctly.
+esriConfig.assetsPath = "./assets"; // relative to when running in root
 
 const map = new WebMap({
   portalItem: {


### PR DESCRIPTION
Document setting config.assetsPath. This will be required at 4.19.
Implement consistent naming convention for the default export: `esriConfig`