### PR TITLE
Update jsapi-vue-cli sample

### DIFF
--- a/esm-samples/jsapi-vue-cli/package.json
+++ b/esm-samples/jsapi-vue-cli/package.json
@@ -3,28 +3,25 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "vue-cli-service serve",
+    "serve": "vue-cli-service serve --open --port 3001 --host localhost",
     "build": "ncp ./node_modules/@arcgis/core/assets ./public/assets && vue-cli-service build",
-    "lint": "vue-cli-service lint",
-    "serve": "serve dist -p 3001",
     "postinstall": "ncp ./node_modules/@arcgis/core/assets ./public/assets"
   },
   "dependencies": {
     "@arcgis/core": "^4.18.1",
-    "core-js": "^3.6.5",
-    "vue": "^3.0.0"
+    "@vue/cli": "^4.5.11",
+    "core-js": "^3.6.5"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "~4.5.0",
-    "@vue/cli-plugin-eslint": "~4.5.0",
-    "@vue/cli-service": "~4.5.0",
+    "@vue/cli-plugin-babel": "^4.5.11",
+    "@vue/cli-plugin-eslint": "^4.5.11",
+    "@vue/cli-service": "^4.5.11",
     "@vue/compiler-sfc": "^3.0.0",
     "babel-eslint": "^10.1.0",
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^7.0.0-0",
     "moment-locales-webpack-plugin": "^1.2.0",
     "ncp": "^2.0.0",
-    "serve": "^11.3.2",
     "webpack-cli": "^3.3.12"
   },
   "eslintConfig": {


### PR DESCRIPTION
This PR fixes an issue with HMR not working in the `/esm-samples/jsapi-vue-cli` sample.

* Updated @vue/cli and related plugins
* Refactored npm scripts
* Removed unused dependencies
* Fixed WDS (webpack development server) disconnecting problems.