### PR TITLE
Reference import typo

### DIFF
--- a/esm-samples/README.md
+++ b/esm-samples/README.md
@@ -13,7 +13,7 @@ npm install @arcgis/core
 Then use `import` statements to load individual modules.
 
 ```js
-import WebMap from '@arcgis/core/Map';
+import Map from '@arcgis/core/Map';
 import MapView from '@arcgis/core/views/MapView';
 
 const map = new Map({


### PR DESCRIPTION
The example is missing or referencing Map with an incorrect export feature of WebMap. The correct export feature should be Map.