### PR TITLE
fix esm rollup npm start script

### DIFF
--- a/esm-samples/rollup/package.json
+++ b/esm-samples/rollup/package.json
@@ -18,6 +18,6 @@
     "build": "rollup -c",
     "watch": "rollup -c -w",
     "dev": "npm-run-all --parallel start watch",
-    "start": "serve public",
+    "start": "serve public"
   }
 }


### PR DESCRIPTION
a trailing comma in package.json was causing npm start to fail