### PR TITLE
Webpack sample - replace CleanWebpackPlugin

### DIFF
--- a/esm-samples/webpack/package.json
+++ b/esm-samples/webpack/package.json
@@ -4,7 +4,6 @@
     "@arcgis/core": "^4.19.0"
   },
   "devDependencies": {
-    "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^5.0.0",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.3.1",

--- a/esm-samples/webpack/webpack.config.js
+++ b/esm-samples/webpack/webpack.config.js
@@ -1,6 +1,5 @@
 const path = require('path');
 
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
@@ -12,7 +11,8 @@ module.exports = {
   output: {
     path: path.join(__dirname, 'dist'),
     chunkFilename: 'chunks/[id].js',
-    publicPath: ''
+    publicPath: '',
+    clean: true
   },
   devServer: {
     contentBase: path.join(__dirname, 'dist'),
@@ -36,7 +36,6 @@ module.exports = {
     ]
   },
   plugins: [
-    new CleanWebpackPlugin(),   
     new HtmlWebPackPlugin({
       title: 'ArcGIS API  for JavaScript',
       template: './public/index.html',


### PR DESCRIPTION
Replace `CleanWebpackPlugin` with `output.clean = true;`. This is an updated approach in Webpack 5 that also removes the additional plugin dependency.

Reference: https://webpack.js.org/guides/output-management/#cleaning-up-the-dist-folder 