### PR TITLE
Add note about using TypeScript with autocasting.

### DIFF
--- a/4.x/typescript/README.md
+++ b/4.x/typescript/README.md
@@ -5,23 +5,20 @@ The [arcgis-js-api.d.ts](arcgis-js-api.d.ts) file provides type definitions for 
 A copy of this file is also available at [DefinitelyTyped][1] and may be installed using the command:  
 `npm install --save @types/arcgis-js-api`
 
+Currently, due to limitations in TypeScript, the APIs [autocasting](https://developers.arcgis.com/javascript/latest/programming-patterns/#autocasting) functionality works best in non-TypeScript applications. No changes are required if you are already using the API without any TypeScript build errors.
+
 ## Requirements
 
-* [TypeScript][3] 2.7+
+* [TypeScript][2] 2.7+
 
 ## Resources
 
-* [Microsoft TypeScript Wiki][5]
-* [TypeScript Editor Support][6]
-* [The Definitive TypeScript Guide][7] from SitePen
-* Type definitions for Dojo are available [here][8].
-* Type definitions for many other libraries are available [here][9].
-
+* [TypeScript Editor Support][3]
+* [Type definitions for Dojo][4].
+* Type definitions for many other libraries are available [here][5].
 
 [1]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/arcgis-js-api
-[3]: http://www.typescriptlang.org/
-[5]: https://github.com/Microsoft/TypeScript/wiki
-[6]: https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support
-[7]: https://www.sitepen.com/blog/2018/10/29/update-the-definitive-typescript-guide/
-[8]: https://github.com/dojo/typings
-[9]: https://github.com/DefinitelyTyped/DefinitelyTyped
+[2]: http://www.typescriptlang.org/
+[3]: https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support
+[4]: https://github.com/dojo/typings
+[5]: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/4.x/typescript/README.md
+++ b/4.x/typescript/README.md
@@ -14,11 +14,9 @@ Currently, due to limitations in TypeScript, the APIs [autocasting](https://deve
 ## Resources
 
 * [TypeScript Editor Support][3]
-* [Type definitions for Dojo][4].
-* Type definitions for many other libraries are available [here][5].
+* Type definitions for many other libraries are available [here][4].
 
 [1]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/arcgis-js-api
 [2]: http://www.typescriptlang.org/
 [3]: https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support
-[4]: https://github.com/dojo/typings
-[5]: https://github.com/DefinitelyTyped/DefinitelyTyped
+[4]: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/4.x/webpack/demo/README.md
+++ b/4.x/webpack/demo/README.md
@@ -14,7 +14,9 @@ npm run build
 
 ## TypeScript Typings
 
-You can use the typings included with `arcgis-js-api` two ways.
+Currently, due to limitations in TypeScript, the APIs [autocasting](https://developers.arcgis.com/javascript/latest/programming-patterns/#autocasting) functionality works best in non-TypeScript applications. No changes are required if you are already using the API without any TypeScript build errors. 
+
+You can use the typings included with `arcgis-js-api` two ways. 
 
 ### Include a `///` directive in your main TypeScript file.
 ```ts
@@ -26,11 +28,8 @@ You can use the typings included with `arcgis-js-api` two ways.
 ```json
 // tsconfig.json
 {
-  "compilerOptions": {},
-  "include": [
-    "node_modules/arcgis-js-api/index.d.ts",
-    "src/**/*.ts",
-    "src/**/*.tsx"
-  ]
+  "compilerOptions": {
+    "types": ["arcgis-js-api"]
+  },
 }
 ```

--- a/4.x/webpack/demo/README.md
+++ b/4.x/webpack/demo/README.md
@@ -24,7 +24,7 @@ You can use the typings included with `arcgis-js-api` two ways.
 /// <reference types="arcgis-js-api" />
 ```
 
-### Or add to the `include` of your `tsconfig.json`.
+### Or add to `types` in `tsconfig.json`.
 ```json
 // tsconfig.json
 {

--- a/4.x/webpack/demo/README.md
+++ b/4.x/webpack/demo/README.md
@@ -24,12 +24,15 @@ You can use the typings included with `arcgis-js-api` two ways.
 /// <reference types="arcgis-js-api" />
 ```
 
-### Or add to `types` in `tsconfig.json`.
+### Or add to the `include` of your `tsconfig.json`.
 ```json
 // tsconfig.json
 {
-  "compilerOptions": {
-    "types": ["arcgis-js-api"]
-  },
+  "compilerOptions": {},
+  "include": [
+    "node_modules/arcgis-js-api/index.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ]
 }
 ```

--- a/4.x/webpack/demo/README.md
+++ b/4.x/webpack/demo/README.md
@@ -1,6 +1,11 @@
-# Sample using @arcgis/webpack-plugin
+[![deprecated](http://badges.github.io/stability-badges/dist/deprecated.svg)](http://github.com/badges/stability-badges)
+
+
+# Sample using @arcgis/webpack-plugin (Deprecated)
 
 ## Usage
+
+**Deprecation Notice**: if you are planning on building a new application, we recommend using the [@arcgis/core](https://developers.arcgis.com/javascript/latest/es-modules/) ES modules, here is a [sample application](https://github.com/Esri/jsapi-resources/tree/master/esm-samples/webpack).
 
 ```
 npm install

--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -36,6 +36,10 @@ For additional information, see the [Build with ES modules](https://developers.a
 
 * If you are using Zone.js, the minimum version is `0.11.4 (February 10, 2021)` or greater.
 
+## TypeScript
+
+Currently, due to limitations in TypeScript, the APIs [autocasting](https://developers.arcgis.com/javascript/latest/programming-patterns/#autocasting) functionality works best in non-TypeScript applications. No changes are required if you are already using the API without any TypeScript build errors.
+
 ## Commands
 
 For a list of all available `npm` commands see the scripts in `package.json`. 


### PR DESCRIPTION
This adds temporary notices about current limitations in TypeScript when using it with autocasting. It's mainly aimed at devs who are copying API samples or code snippets, since many of them use autocasting.

Also includes other minor touchups in the READMEs.