### PR TITLE
AMD webpack sample deprecation notice.

### DIFF
--- a/4.x/webpack/README.md
+++ b/4.x/webpack/README.md
@@ -1,7 +1,9 @@
-# Using Webpack with the ArcGIS API for JavaScript
+[![deprecated](http://badges.github.io/stability-badges/dist/deprecated.svg)](http://github.com/badges/stability-badges)
+
+# Using Webpack with the ArcGIS API for JavaScript (Deprecated)
+
+**Deprecation Notice**: if you are planning on building a new application, we recommend using the [@arcgis/core](https://developers.arcgis.com/javascript/latest/es-modules/) ES modules, here is a [sample application](https://github.com/Esri/jsapi-resources/tree/master/esm-samples/webpack).
 
 This [demo application](demo/) is the recommended way to build the [arcgis-js-api](https://github.com/Esri/arcgis-js-api) using using Webpack and the [@arcgis/webpack-plugin](https://github.com/Esri/arcgis-webpack-plugin).
-
-You can read more about Webpack with the ArcGIS API for JavaScript [here](https://developers.arcgis.com/javascript/latest/guide/webpack/).
 
 You can read more about Webpack [here](https://webpack.js.org/).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A collection of resources for developers using the [ArcGIS API for JavaScript](h
 * [ESM samples - Create local builds with frameworks and module bundlers](./esm-samples/)
 
 #### AMD modules
-* [Webpack - Create custom builds of the API](./4.x/webpack/README.md)
 * [Dojo and RequireJS - Create local builds of the API](./4.x/amd/README.md)
 * [TypeScript - Class and interface definitions](./4.x/typescript/README.md)
 


### PR DESCRIPTION
This adds a deprecation notice to the 4.x/webpack/README. We now recommend using ES modules.