### PR TITLE
Update rollup dev build config to disable treeshaking.

### DIFF
--- a/esm-samples/rollup/rollup.config.js
+++ b/esm-samples/rollup/rollup.config.js
@@ -11,6 +11,7 @@ export default {
     dir: "public",
     format: "es"
   },
+  treeshake: false,
   plugins: [
     del({ targets: ["public/chunks"], runOnce: true, verbose: true }),
     resolve(),


### PR DESCRIPTION
Reference #327. This will speed up the dev builds.

With some quick testing on my 2018 Mac, using this repos rollup sample my dev build times improved from approx. 14 seconds to approx. 9 seconds (about 35% improvement).

cc @gavinr  