### PR TITLE
bump webpack to 4.21

### DIFF
--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -2,6 +2,10 @@
 
 This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) ES modules with webpack.
 
+
+## Known Issues
+- ``webpack-dev-server`` had a [breaking change](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#-breaking-changes-4) in ``4.0.0`` which removed ``contentBase`` in favor of the ``static`` option. This sample has been changed accordingly.
+
 ## Get Started
 
 **Step 1** - Run `npm install` and then start adding modules.

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -11,11 +11,11 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 *index.css*
 
 ```css
-@import 'https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
 
 ## Commands
 
-For a list of all available `npm` commands see the scripts in `package.json`. 
+For a list of all available `npm` commands see the scripts in `package.json`.

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -4,7 +4,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 
 
 ## Known Issues
-- ``webpack-dev-server`` had a [breaking change](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#-breaking-changes-4) in ``4.0.0`` which removed ``contentBase`` in favor of the ``static`` option. This sample has been changed accordingly.
+- `webpack-dev-server` had a [breaking change](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#-breaking-changes-4) in `4.0.0` which removed `contentBase` in favor of the `static` option. This sample has been changed accordingly.
 
 ## Get Started
 

--- a/esm-samples/webpack/package.json
+++ b/esm-samples/webpack/package.json
@@ -1,17 +1,17 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.20.0"
+    "@arcgis/core": "^4.21.0"
   },
   "devDependencies": {
-    "css-loader": "^5.2.6",
+    "css-loader": "^6.2.0",
     "file-loader": "^6.2.0",
-    "html-webpack-plugin": "^5.3.1",
-    "mini-css-extract-plugin": "^1.6.0",
+    "html-webpack-plugin": "^5.3.2",
+    "mini-css-extract-plugin": "^2.2.0",
     "source-map-loader": "^3.0.0",
-    "webpack": "^5.38.1",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack": "^5.51.1",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.0.0"
   },
   "scripts": {
     "build": "webpack --mode production",

--- a/esm-samples/webpack/src/index.css
+++ b/esm-samples/webpack/src/index.css
@@ -1,4 +1,4 @@
-@import "https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/dark/main.css";
+@import "https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/dark/main.css";
 html,
 body,
 #viewDiv {

--- a/esm-samples/webpack/webpack.config.js
+++ b/esm-samples/webpack/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
     clean: true
   },
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
+    static: path.join(__dirname, 'dist'),
     compress: true,
     port: 3001,
   },


### PR DESCRIPTION
Had to make a change in the webpack config due to a [breaking change](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#-breaking-changes-4).


> the contentBase, contentBasePublicPath, serveIndex, staticOptions, watchContentBase, watchOptions were removed in favor of the static option
