### PR TITLE
4.21 release

### DIFF
--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -29,7 +29,7 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 *styles.css*
 
 ```css
-  @import 'https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css';
+  @import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
@@ -42,7 +42,7 @@ For additional information, see the [Build with ES modules](https://developers.a
 
 Currently, due to limitations in TypeScript, the APIs [autocasting](https://developers.arcgis.com/javascript/latest/programming-patterns/#autocasting) functionality works best in non-TypeScript applications. No changes are required if you are already using the API without any TypeScript build errors.
 
-Required version is `~4.2.3`.
+Minimum required version is `~4.2.3`.
 
 ## Commands
 

--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -5,6 +5,8 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 ---
 ## Known issues
 
+* If you are seeing `404` errors in the console after updating Angular `12.1.x` dependencies, you should try clearing your browser cache. This is an Angular caching issue. 
+
 * There is an optimization bug affecting production builds at Angular `12.2.x`. It is recommended to stay at Angular `12.1.x` until Angular 13 is ready. For more information: https://github.com/Esri/feedback-js-api-next/issues/131.
 
 * To prevent `Unhandled Promise Rejection` errors when using Angular with Zone.js, upgrade to Angular `11.2.5` or greater, Zone.js `0.11.4`or greater, and switch the `tsconfig.target` to `es2017` or greater.

--- a/esm-samples/jsapi-angular-cli/package.json
+++ b/esm-samples/jsapi-angular-cli/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "~12.1.4",
     "@angular/platform-browser-dynamic": "~12.1.4",
     "@angular/router": "~12.1.4",
-    "@arcgis/core": "^4.20.0",
+    "@arcgis/core": "^4.21.0",
     "rxjs": "^6.6.0",
     "tslib": "^2.0.0",
     "zone.js": "~0.11.4"

--- a/esm-samples/jsapi-angular-cli/src/app/app.component.css
+++ b/esm-samples/jsapi-angular-cli/src/app/app.component.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
 .esri-view {
   padding: 0;
   margin: 0;

--- a/esm-samples/jsapi-create-react-app/README.md
+++ b/esm-samples/jsapi-create-react-app/README.md
@@ -1,6 +1,6 @@
 # ArcGIS API for JavaScript with create-react-app
 
-This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with `create-react-app`. 
+This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with `create-react-app`.
 
 ## Get Started
 
@@ -11,14 +11,14 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 *index.css*
 
 ```css
-@import 'https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
 
 ## Commands
 
-For a list of all available `npm` commands see the scripts in `package.json`. 
+For a list of all available `npm` commands see the scripts in `package.json`.
 
 ## Misc.
 
@@ -51,7 +51,7 @@ module.exports = function override(config, env) {
   // May vary based on version of create-react-app being used.
   config.module.rules[2].oneOf[2].exclude = /(@babel(?:\/|\\{1,2})runtime|node_modules)/;
   return config;
-} 
+}
 ```
 
 ---

--- a/esm-samples/jsapi-create-react-app/package.json
+++ b/esm-samples/jsapi-create-react-app/package.json
@@ -3,14 +3,14 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.20.0",
+    "@arcgis/core": "^4.21.0",
     "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^11.2.7",
-    "@testing-library/user-event": "^13.1.9",
+    "@testing-library/react": "^12.0.0",
+    "@testing-library/user-event": "^13.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^4.0.3",
-    "web-vitals": "^2.0.1"
+    "web-vitals": "^2.1.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/esm-samples/jsapi-create-react-app/src/index.css
+++ b/esm-samples/jsapi-create-react-app/src/index.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.19/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
 html,
 body,
 #root {

--- a/esm-samples/jsapi-custom-workers/README.md
+++ b/esm-samples/jsapi-custom-workers/README.md
@@ -2,6 +2,9 @@
 
 This repo demonstrates using [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) ES modules with custom workers.
 
+## Known Issues
+- `webpack-dev-server` had a [breaking change](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#-breaking-changes-4) in `4.0.0` which removed `contentBase` in favor of the `static` option. This sample has been changed accordingly.
+
 ## Building workers
 
 The key to using custom workers is building the workers separately from your main build. In this demo we use Rollup to build the workers and webpack to build the main application.

--- a/esm-samples/jsapi-custom-workers/README.md
+++ b/esm-samples/jsapi-custom-workers/README.md
@@ -65,7 +65,7 @@ config.workers.loaderUrl = "https://cdn.jsdelivr.net/npm/systemjs@6.10.0/dist/s.
 
   const jsonFeatures = await spatialJoin.invoke("doSpatialJoin", [features1, features2]);
   // Results are returned as JSON, so you can rehydrate to Graphics again
-  const features = jsonFeatures.map(a => Graphic.fromJSON(a));
+  const features = jsonFeatures.map((a) => Graphic.fromJSON(a));
 ```
 
 As you can see, the provided worker framework provides a Promise-based layer on top of workers for easier use. Web workers can only pass native JavaScript objects back and forth. But you can load modules from `@arcgis/core` inside your worker.
@@ -76,8 +76,8 @@ import Graphic from "@arcgis/core/Graphic";
 
 export function doSpatialJoin([f1, f2]) {
   // Rehydrate Graphics
-	const features1 = f1.map(a => Graphic.fromJSON(a));
-	const features2 = f2.map(a => Graphic.fromJSON(a));
+	const features1 = f1.map((a) => Graphic.fromJSON(a));
+	const features2 = f2.map((a) => Graphic.fromJSON(a));
 	const features = [];
 	let temp = [...features1];
 	let temp2 = [];

--- a/esm-samples/jsapi-custom-workers/README.md
+++ b/esm-samples/jsapi-custom-workers/README.md
@@ -1,10 +1,10 @@
 # ArcGIS API for JavaScript with custom workers
 
-This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) esm modules with custom workers.
+This repo demonstrates using [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) ES modules with custom workers.
 
 ## Building workers
 
-The key to using custom workers is that you need to build the workers separately from your main build. In this demo we use Rollup to build the workers and webpack to build the main application.
+The key to using custom workers is building the workers separately from your main build. In this demo we use Rollup to build the workers and webpack to build the main application.
 
 ```js
 // rollup.worker.config.js
@@ -16,7 +16,7 @@ const production = !process.env.ROLLUP_WATCH;
 
 export default {
   input: {
-    // JSAPI RemoteClient for using workers
+    // ArcGIS JS API RemoteClient for using workers
     RemoteClient: "@arcgis/core/core/workers/RemoteClient.js",
     // User custom worker
     SpatialJoin: "./src/spatial-join-worker.js"
@@ -24,7 +24,7 @@ export default {
   output: {
     chunkFileNames: "chunks/worker/[name]-[hash].js",
     dir: "dist",
-    // can use loader of choice, but System works well
+    // You can use the loader of your own choice, but System works well
     // in a production environment
     format: "system",
     exports: "named"
@@ -65,14 +65,14 @@ config.workers.loaderUrl = "https://cdn.jsdelivr.net/npm/systemjs@6.10.0/dist/s.
   const features = jsonFeatures.map(a => Graphic.fromJSON(a));
 ```
 
-As you can see, the provided worker framework provides a Promise based layer on top of workers for easier use. Web workers can only pass native JavaScript objects back and forth. But you can load modules from `@arcgis/core` inside your worker.
+As you can see, the provided worker framework provides a Promise-based layer on top of workers for easier use. Web workers can only pass native JavaScript objects back and forth. But you can load modules from `@arcgis/core` inside your worker.
 
 ```js
 // spatial-join-worker.js
 import Graphic from "@arcgis/core/Graphic";
 
 export function doSpatialJoin([f1, f2]) {
-    // rehydrate Graphics
+  // Rehydrate Graphics
 	const features1 = f1.map(a => Graphic.fromJSON(a));
 	const features2 = f2.map(a => Graphic.fromJSON(a));
 	const features = [];
@@ -89,7 +89,7 @@ export function doSpatialJoin([f1, f2]) {
 				temp.splice(i, 1);
 			}
 		}
-        // convert graphics to JSON objects
+    // Convert graphics to JSON objects
 		features.push(graphic.toJSON());
 	}
     return features;

--- a/esm-samples/jsapi-custom-workers/package.json
+++ b/esm-samples/jsapi-custom-workers/package.json
@@ -1,22 +1,22 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.19.0"
+    "@arcgis/core": "^4.21.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^19.0.0",
-    "@rollup/plugin-node-resolve": "^13.0.0",
-    "css-loader": "^5.0.0",
+    "@rollup/plugin-commonjs": "^20.0.0",
+    "@rollup/plugin-node-resolve": "^13.0.4",
+    "css-loader": "^6.2.0",
     "file-loader": "^6.2.0",
-    "html-webpack-plugin": "^5.3.1",
-    "mini-css-extract-plugin": "^1.4.0",
+    "html-webpack-plugin": "^5.3.2",
+    "mini-css-extract-plugin": "^2.3.0",
     "npm-run-all": "^4.1.5",
-    "rollup": "^2.51.1",
+    "rollup": "^2.56.3",
     "rollup-plugin-terser": "^7.0.2",
-    "source-map-loader": "^2.0.1",
-    "webpack": "^5.39.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.0"
+    "source-map-loader": "^3.0.0",
+    "webpack": "^5.52.1",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.2.1"
   },
   "scripts": {
     "build": "npm-run-all clean --parallel build:*",

--- a/esm-samples/jsapi-custom-workers/public/index.html
+++ b/esm-samples/jsapi-custom-workers/public/index.html
@@ -5,6 +5,7 @@
     <title>Custom Workers</title>
   </head>
   <body>
+    <button id="btn-1">Run spatial Join</button>
     <div id="viewDiv"></div>
   </body>
 </html>

--- a/esm-samples/jsapi-custom-workers/src/index.css
+++ b/esm-samples/jsapi-custom-workers/src/index.css
@@ -1,4 +1,4 @@
-@import "https://js.arcgis.com/4.19/@arcgis/core/assets/esri/themes/dark/main.css";
+@import "https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/dark/main.css";
 html,
 body,
 #viewDiv {
@@ -7,4 +7,10 @@ body,
   height: 100%;
   width: 100%;
   background: rgba(50, 50, 50);
+}
+#btn-1 {
+  width: 100%;
+  height: 30px;
+  background-color: #4CAF50;
+  display: none;
 }

--- a/esm-samples/jsapi-custom-workers/src/index.js
+++ b/esm-samples/jsapi-custom-workers/src/index.js
@@ -10,7 +10,9 @@ import * as workers from "@arcgis/core/core/workers";
 
 config.workers.workerPath = "./RemoteClient.js";
 
-config.workers.loaderUrl = "https://cdn.jsdelivr.net/npm/systemjs@6.10.0/dist/s.min.js";
+config.workers.loaderUrl = "https://cdn.jsdelivr.net/npm/systemjs@6.10.3/dist/s.min.js";
+
+const button1 = document.getElementById("btn-1");
 
 const cityLayer = new FeatureLayer({
   portalItem: {
@@ -37,9 +39,18 @@ const view = new MapView({
 });
 
 const legend = new Legend({ view });
+view.ui.add(button1, "top-right");
 view.ui.add(legend, "top-right");
+button1.style.display = "block";
 
-view.when(async () => {
+view.when(() => {
+  button1.onclick = () => {
+    console.log("Running local spatial join operation in a worker...");
+    runJoin();
+  }
+});
+
+async function runJoin() {
   const [cityLayerView, frsLayerView] = await Promise.all([
     view.whenLayerView(cityLayer),
     view.whenLayerView(frsLayer)
@@ -57,7 +68,7 @@ view.when(async () => {
   const features2 = cityResults.features.map((a) => a.toJSON());
 
   const jsonFeatures = await spatialJoin.invoke("doSpatialJoin", [features1, features2]);
-  const features = jsonFeatures.map(a => Graphic.fromJSON(a));
+  const features = jsonFeatures.map((a) => Graphic.fromJSON(a));
 
   map.removeMany([cityLayer, frsLayer]);
   const joinLayer = await createLayer(cityLayer, features, [
@@ -77,7 +88,7 @@ view.when(async () => {
 
   joinLayer.renderer = renderer;
   map.add(joinLayer);
-});
+}
 
 async function createLayer(layer, source, extraFields) {
   await layer.load();

--- a/esm-samples/jsapi-custom-workers/webpack.config.js
+++ b/esm-samples/jsapi-custom-workers/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     clean: true
   },
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
+    static: './dist',
     compress: true,
     port: 3001,
   },
@@ -46,7 +46,5 @@ module.exports = {
       filename: "[name].[chunkhash].css",
       chunkFilename: "[id].css"
     })
-  ],
-  // temporary fix for non-api related warning
-  ignoreWarnings: [/Failed to parse source map/]
+  ]
 };

--- a/esm-samples/jsapi-custom-workers/webpack.config.js
+++ b/esm-samples/jsapi-custom-workers/webpack.config.js
@@ -10,11 +10,10 @@ module.exports = {
   node: false,
   output: {
     path: path.join(__dirname, 'dist'),
-    chunkFilename: 'chunks/[id].js',
-    clean: true
+    chunkFilename: 'chunks/[id].js'
   },
   devServer: {
-    static: './dist',
+    static: path.join(__dirname, 'dist'),
     compress: true,
     port: 3001,
   },

--- a/esm-samples/jsapi-ember-cli/README.md
+++ b/esm-samples/jsapi-ember-cli/README.md
@@ -2,6 +2,13 @@
 
 This repo integrates [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) using [embroider](https://github.com/embroider-build/embroider).
 
+---
+**NOTE**
+
+This sample is no longer being maintained. We will try our best to answer any questions you have on the [github issues](https://github.com/Esri/jsapi-resources/issues) page. 
+
+---
+
 ## Get Started
 
 **Step 1** - Run `npm install` and then start adding modules.

--- a/esm-samples/jsapi-esm-cdn/esm-cdn.html
+++ b/esm-samples/jsapi-esm-cdn/esm-cdn.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no" />
   <title>ArcGIS ESM CDN</title>
 
-  <link rel="stylesheet" href="https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css" />
+  <link rel="stylesheet" href="https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css" />
 
   <style>
     html,
@@ -19,10 +19,10 @@
     }
   </style>
   <script type="module">
-    import WebMap from 'https://js.arcgis.com/4.20/@arcgis/core/WebMap.js';
-    import MapView from 'https://js.arcgis.com/4.20/@arcgis/core/views/MapView.js';
-    import Bookmarks from 'https://js.arcgis.com/4.20/@arcgis/core/widgets/Bookmarks.js';
-    import Expand from 'https://js.arcgis.com/4.20/@arcgis/core/widgets/Expand.js';
+    import WebMap from 'https://js.arcgis.com/4.21/@arcgis/core/WebMap.js';
+    import MapView from 'https://js.arcgis.com/4.21/@arcgis/core/views/MapView.js';
+    import Bookmarks from 'https://js.arcgis.com/4.21/@arcgis/core/widgets/Bookmarks.js';
+    import Expand from 'https://js.arcgis.com/4.21/@arcgis/core/widgets/Expand.js';
 
     const webmap = new WebMap({
       portalItem: {

--- a/esm-samples/jsapi-node/README.md
+++ b/esm-samples/jsapi-node/README.md
@@ -13,6 +13,8 @@ esriConfig.assetsPath = "node_modules/@arcgis/core/assets"; // relative to when 
 
 An example can be found in [`projection.js`](https://github.com/Esri/jsapi-resources/blob/master/esm-samples/jsapi-node/src/projection.js#L6).
 
+More information can be found in the [Workding with assets](https://developers.arcgis.com/javascript/latest/es-modules/#working-with-assets) guide topic.
+
 ## Polyfills
 
 Because Node does not have a native `fetch` or `abort-controller`, you will need to load polyfills:

--- a/esm-samples/jsapi-node/package.json
+++ b/esm-samples/jsapi-node/package.json
@@ -1,16 +1,16 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.20.0",
+    "@arcgis/core": "^4.21.0",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.4",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-delete": "^2.0.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^19.0.0",
-    "@rollup/plugin-node-resolve": "^13.0.0",
-    "rollup": "^2.51.1"
+    "@rollup/plugin-commonjs": "^20.0.0",
+    "@rollup/plugin-node-resolve": "^13.0.4",
+    "rollup": "^2.56.3"
   },
   "scripts": {
     "build": "rollup -c"

--- a/esm-samples/jsapi-vue-cli/.eslintrc
+++ b/esm-samples/jsapi-vue-cli/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "parser": "@babel/eslint-parser",
+  "parserOptions": {
+    "requireConfigFile": "false"
+  },
+  "babelOptions": {
+    "configFile": "./babel.config.js"
+  }
+}

--- a/esm-samples/jsapi-vue-cli/README.md
+++ b/esm-samples/jsapi-vue-cli/README.md
@@ -12,11 +12,15 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 
 ```css
 <style>
-  @import 'https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css';
+  @import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
 </style>
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
+
+## Production builds
+
+Be sure to correctly set the build path in `vue.config.js`. For more information see the [Deployment](https://cli.vuejs.org/guide/deployment.html#deployment) guide.
 
 ## Commands
 

--- a/esm-samples/jsapi-vue-cli/package.json
+++ b/esm-samples/jsapi-vue-cli/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "@arcgis/core": "^4.21.0-next.20210915",
+    "@arcgis/core": "^4.21.0",
     "core-js": "^3.17.3",
     "vue": "^3.2.11"
   },

--- a/esm-samples/jsapi-vue-cli/package.json
+++ b/esm-samples/jsapi-vue-cli/package.json
@@ -7,19 +7,19 @@
     "build": "vue-cli-service build"
   },
   "dependencies": {
-    "@arcgis/core": "^4.20.0",
-    "core-js": "^3.6.5",
-    "vue": "^3.1.1"
+    "@arcgis/core": "^4.21.0-next.20210915",
+    "core-js": "^3.17.3",
+    "vue": "^3.2.11"
   },
   "devDependencies": {
-    "@babel/eslint-parser": "^7.14.5",
+    "@babel/eslint-parser": "^7.15.4",
     "@vue/cli": "^4.5.13",
     "@vue/cli-plugin-babel": "^4.5.13",
     "@vue/cli-plugin-eslint": "^4.5.13",
     "@vue/cli-service": "^4.5.13",
-    "@vue/compiler-sfc": "^3.1.1",
-    "eslint": "^7.28.0",
-    "eslint-plugin-vue": "^7.10.0"
+    "@vue/compiler-sfc": "^3.2.11",
+    "eslint": "^7.32.0",
+    "eslint-plugin-vue": "^7.17.0"
   },
   "eslintConfig": {
     "root": true,

--- a/esm-samples/jsapi-vue-cli/public/index.html
+++ b/esm-samples/jsapi-vue-cli/public/index.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title><%= htmlWebpackPlugin.options.title %></title>
+    <title>VueJS and ArcGIS JS API</title>
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong>We're sorry but this app doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/esm-samples/jsapi-vue-cli/src/App.vue
+++ b/esm-samples/jsapi-vue-cli/src/App.vue
@@ -18,6 +18,7 @@ export default {
     });
 
     const view = new MapView({
+      // https://v3.vuejs.org/api/instance-properties.html#el
       container: this.$el,
       map: webmap,
     });

--- a/esm-samples/jsapi-vue-cli/src/App.vue
+++ b/esm-samples/jsapi-vue-cli/src/App.vue
@@ -6,7 +6,7 @@
 import WebMap from "@arcgis/core/WebMap";
 import MapView from "@arcgis/core/views/MapView";
 import Bookmarks from "@arcgis/core/widgets/Bookmarks";
-import Expand from "@arcgis/core/widgets/Expand";
+import Expand from "@arcgis/core/widgets/Expand"; 
 
 export default {
   name: 'App',
@@ -49,24 +49,6 @@ export default {
 }
 </script>
 
-<style>
-@import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
-html,
-body,
-#app {
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: center;
-  color: #2c3e50;
-  padding: 0;
-  margin: 0;
-  width: 100%;
-  height: 100%;
-}
-.mapdiv {
-  padding: 0;
-  margin: 0;
-  height: 100%;
-}
+<style scoped>
+  @import './main.css';
 </style>

--- a/esm-samples/jsapi-vue-cli/src/App.vue
+++ b/esm-samples/jsapi-vue-cli/src/App.vue
@@ -50,7 +50,7 @@ export default {
 </script>
 
 <style>
-@import 'https://js.arcgis.com/4.19/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
 html,
 body,
 #app {

--- a/esm-samples/jsapi-vue-cli/src/main.css
+++ b/esm-samples/jsapi-vue-cli/src/main.css
@@ -1,0 +1,19 @@
+@import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
+html,
+body,
+#app {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+  color: #2c3e50;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+}
+.mapdiv {
+  padding: 0;
+  margin: 0;
+  height: 100%;
+}

--- a/esm-samples/jsapi-vue-cli/vue.config.js
+++ b/esm-samples/jsapi-vue-cli/vue.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  publicPath: process.env.NODE_ENV === "production" ? "/my-project/" : "/"
+};

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -11,11 +11,11 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 *index.html*
 
 ```html
- <link rel="stylesheet" href="https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css>
+ <link rel="stylesheet" href="https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css>
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
 
 ## Commands
 
-For a list of all available `npm` commands see the scripts in `package.json`. 
+For a list of all available `npm` commands see the scripts in `package.json`.

--- a/esm-samples/rollup/package.json
+++ b/esm-samples/rollup/package.json
@@ -1,14 +1,14 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.20.0"
+    "@arcgis/core": "^4.21.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^19.0.0",
-    "@rollup/plugin-node-resolve": "^13.0.0",
-    "rollup": "^2.51.1",
+    "@rollup/plugin-commonjs": "^20.0.0",
+    "@rollup/plugin-node-resolve": "^13.0.4",
+    "rollup": "^2.56.3",
     "rollup-plugin-delete": "^2.0.0",
-    "rollup-plugin-livereload": "^2.0.0",
+    "rollup-plugin-livereload": "^2.0.5",
     "rollup-plugin-serve": "^1.1.0",
     "rollup-plugin-terser": "^7.0.2"
   },

--- a/esm-samples/rollup/public/index.html
+++ b/esm-samples/rollup/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Rollup Sample</title>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/dark/main.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/dark/main.css" />
     <style>
       html,
       body,

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -2,6 +2,10 @@
 
 This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) ES modules with webpack.
 
+
+## Known Issues
+- `webpack-dev-server` had a [breaking change](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#-breaking-changes-4) in `4.0.0` which removed `contentBase` in favor of the `static` option. This sample has been changed accordingly.
+
 ## Get Started
 
 **Step 1** - Run `npm install` and then start adding modules.
@@ -11,11 +15,11 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 *index.css*
 
 ```css
-@import 'https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
 
 ## Commands
 
-For a list of all available `npm` commands see the scripts in `package.json`. 
+For a list of all available `npm` commands see the scripts in `package.json`.

--- a/esm-samples/webpack/package.json
+++ b/esm-samples/webpack/package.json
@@ -1,17 +1,17 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.20.0"
+    "@arcgis/core": "^4.21.0"
   },
   "devDependencies": {
-    "css-loader": "^5.2.6",
+    "css-loader": "^6.2.0",
     "file-loader": "^6.2.0",
-    "html-webpack-plugin": "^5.3.1",
-    "mini-css-extract-plugin": "^1.6.0",
+    "html-webpack-plugin": "^5.3.2",
+    "mini-css-extract-plugin": "^2.2.0",
     "source-map-loader": "^3.0.0",
-    "webpack": "^5.38.1",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "webpack": "^5.51.1",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.0.0"
   },
   "scripts": {
     "build": "webpack --mode production",

--- a/esm-samples/webpack/src/index.css
+++ b/esm-samples/webpack/src/index.css
@@ -1,4 +1,4 @@
-@import "https://js.arcgis.com/4.20/@arcgis/core/assets/esri/themes/dark/main.css";
+@import "https://js.arcgis.com/4.21/@arcgis/core/assets/esri/themes/dark/main.css";
 html,
 body,
 #viewDiv {

--- a/esm-samples/webpack/webpack.config.js
+++ b/esm-samples/webpack/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = {
     clean: true
   },
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
+    static: path.join(__dirname, 'dist'),
     compress: true,
     port: 3001,
   },


### PR DESCRIPTION
Update all esm samples to 4.21.

Notable items:
* Added notice to ember sample that it will no longer be maintained
* Added additional configuration to Vue sample to allow for production build testing
* Added note to Angular sample about browser caching when updating dependencies
* Minor modification to custom workers sample to delay running worker until button is clicked
* Replaced webpack.config's `devServer.contentBase` with `static` in two samples 