### PR TITLE
Add rollup TypeScript example

### DIFF
--- a/esm-samples/rollup-ts/.gitignore
+++ b/esm-samples/rollup-ts/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+package-lock.json
+public/assets
+public/chunks
+public/*.js

--- a/esm-samples/rollup-ts/README.md
+++ b/esm-samples/rollup-ts/README.md
@@ -1,0 +1,21 @@
+# ArcGIS API for JavaScript with rollup & TypeScript
+
+This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) ES modules with rollup and TypeScript.
+
+## Get Started
+
+**Step 1** - Run `npm install` and then start adding modules
+
+**Step 2** Configure CSS. Here's a basic HTML example:
+
+*index.html*
+
+```html
+ <link rel="stylesheet" href="https://js.arcgis.com/4.22/@arcgis/core/assets/esri/themes/light/main.css>
+```
+
+For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
+
+## Commands
+
+For a list of all available `npm` commands see the scripts in `package.json`.

--- a/esm-samples/rollup-ts/package.json
+++ b/esm-samples/rollup-ts/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "dependencies": {
+    "@arcgis/core": "^4.22.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^13.0.6",
+    "@rollup/plugin-typescript": "^8.3.0",
+    "rollup": "^2.60.2",
+    "rollup-plugin-delete": "^2.0.0",
+    "rollup-plugin-terser": "^7.0.2",
+    "tslib": "^2.3.1",
+    "typescript": "^4.5.4"
+  },
+  "scripts": {
+    "build": "rollup -c rollup.config.js",
+    "build:prod": "rollup -c rollup.config.prod.js"
+  }
+}

--- a/esm-samples/rollup-ts/public/index.html
+++ b/esm-samples/rollup-ts/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Rollup Sample</title>
+    <link rel="stylesheet" href="https://js.arcgis.com/4.22/@arcgis/core/assets/esri/themes/dark/main.css" />
+    <style>
+      html,
+      body,
+      #viewDiv {
+        padding: 0;
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+    <script type="module" src="./main.js"></script>
+  </head>
+  <body>
+    <div id="viewDiv"></div>
+  </body>
+</html>

--- a/esm-samples/rollup-ts/rollup.config.js
+++ b/esm-samples/rollup-ts/rollup.config.js
@@ -1,0 +1,20 @@
+import del from "rollup-plugin-delete";
+import resolve from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+
+export default {
+  input: "src/main.ts",
+  output: {
+    chunkFileNames: "chunks/[name]-[hash].js",
+    dir: "public",
+    format: "es",
+    generatedCode: "es2015" // Rollup files only, not user code
+  },
+  treeshake: false,
+  plugins: [
+    del({ targets: ["public/chunks"], runOnce: true, verbose: true }),
+    resolve(),
+    typescript()
+  ],
+  preserveEntrySignatures: false
+};

--- a/esm-samples/rollup-ts/rollup.config.prod.js
+++ b/esm-samples/rollup-ts/rollup.config.prod.js
@@ -1,0 +1,21 @@
+import del from "rollup-plugin-delete";
+import resolve from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import { terser } from "rollup-plugin-terser";
+
+export default {
+  input: "src/main.ts",
+  output: {
+    chunkFileNames: "chunks/[name]-[hash].js",
+    dir: "public",
+    format: "es",
+    generatedCode: "es2015" // Rollup files only, not user code
+  },
+  plugins: [
+    del({ targets: ["public/chunks"], runOnce: true, verbose: true }),
+    resolve(),
+    typescript(),
+    terser()
+  ],
+  preserveEntrySignatures: false
+};

--- a/esm-samples/rollup-ts/src/main.ts
+++ b/esm-samples/rollup-ts/src/main.ts
@@ -1,0 +1,189 @@
+import Bookmarks from "@arcgis/core/widgets/Bookmarks";
+import DotDensityRenderer from "@arcgis/core/renderers/DotDensityRenderer";
+import Expand from "@arcgis/core/widgets/Expand";
+import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
+import Legend from "@arcgis/core/widgets/Legend";
+import MapView from "@arcgis/core/views/MapView";
+import WebMap from "@arcgis/core/WebMap";
+
+const map = new WebMap({
+  portalItem: {
+    id: "56b5bd522c52409c90d902285732e9f1",
+  },
+});
+
+const view = new MapView({
+  container: "viewDiv",
+  map: map,
+  highlightOptions: {
+    fillOpacity: 0,
+    color: [50, 50, 50],
+  },
+  popup: {
+    dockEnabled: true,
+    dockOptions: {
+      position: "top-right",
+      breakpoint: false,
+    },
+  },
+  constraints: {
+    maxScale: 35000,
+  },
+});
+
+view.when().then(function () {
+  const dotDensityRenderer = new DotDensityRenderer({
+    dotValue: 100,
+    outline: null,
+    referenceScale: 577790, // 1:577,790 view scale
+    legendOptions: {
+      unit: "people",
+    },
+    attributes: [
+      {
+        field: "B03002_003E",
+        color: "#f23c3f",
+        label: "White (non-Hispanic)",
+      },
+      {
+        field: "B03002_012E",
+        color: "#e8ca0d",
+        label: "Hispanic",
+      },
+      {
+        field: "B03002_004E",
+        color: "#00b6f1",
+        label: "Black or African American",
+      },
+      {
+        field: "B03002_006E",
+        color: "#32ef94",
+        label: "Asian",
+      },
+      {
+        field: "B03002_005E",
+        color: "#ff7fe9",
+        label: "American Indian/Alaskan Native",
+      },
+      {
+        field: "B03002_007E",
+        color: "#e2c4a5",
+        label: "Pacific Islander/Hawaiian Native",
+      },
+      {
+        field: "B03002_008E",
+        color: "#ff6a00",
+        label: "Other race",
+      },
+      {
+        field: "B03002_009E",
+        color: "#96f7ef",
+        label: "Two or more races",
+      },
+    ],
+  });
+
+  // Add renderer to the layer and define a popup template
+  const url =
+    "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/ACS_Population_by_Race_and_Hispanic_Origin_Boundaries/FeatureServer/2";
+  const layer = new FeatureLayer({
+    url: url,
+    minScale: 20000000,
+    maxScale: 35000,
+    title: "Current Population Estimates (ACS)",
+    popupTemplate: {
+      title: "{County}, {State}",
+      content: [
+        {
+          type: "fields",
+          fieldInfos: [
+            {
+              fieldName: "B03002_003E",
+              label: "White (non-Hispanic)",
+              format: {
+                digitSeparator: true,
+                places: 0,
+              },
+            },
+            {
+              fieldName: "B03002_012E",
+              label: "Hispanic",
+              format: {
+                digitSeparator: true,
+                places: 0,
+              },
+            },
+            {
+              fieldName: "B03002_004E",
+              label: "Black or African American",
+              format: {
+                digitSeparator: true,
+                places: 0,
+              },
+            },
+            {
+              fieldName: "B03002_006E",
+              label: "Asian",
+              format: {
+                digitSeparator: true,
+                places: 0,
+              },
+            },
+            {
+              fieldName: "B03002_005E",
+              label: "American Indian/Alaskan Native",
+              format: {
+                digitSeparator: true,
+                places: 0,
+              },
+            },
+            {
+              fieldName: "B03002_007E",
+              label: "Pacific Islander/Hawaiian Native",
+              format: {
+                digitSeparator: true,
+                places: 0,
+              },
+            },
+            {
+              fieldName: "B03002_008E",
+              label: "Other race",
+              format: {
+                digitSeparator: true,
+                places: 0,
+              },
+            },
+            {
+              fieldName: "B03002_009E",
+              label: "Two or more races",
+              format: {
+                digitSeparator: true,
+                places: 0,
+              },
+            },
+          ],
+        },
+      ],
+    },
+    renderer: dotDensityRenderer,
+  });
+
+  map.add(layer);
+
+  view.ui.add(
+    [
+      new Expand({
+        view: view,
+        content: new Legend({ view: view }),
+        group: "top-left",
+        expanded: true,
+      }),
+      new Expand({
+        view: view,
+        content: new Bookmarks({ view: view }),
+        group: "top-left",
+      }),
+    ],
+    "top-left"
+  );
+});

--- a/esm-samples/rollup-ts/tsconfig.json
+++ b/esm-samples/rollup-ts/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
+    "declaration": false,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "importsNotUsedAsValues": "preserve",
+    "lib": ["dom", "es2020"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "target": "es2020"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Adapted the [esm-samples/rollup](https://github.com/Esri/jsapi-resources/tree/master/esm-samples/rollup) example to use a TypeScript source.

_Does not include "watch" feature in dev build only because I couldn't get either rollup's watch or rollup-plugin-watch to trigger a build upon a change to the TypeScript file, and so public/main.js wasn't changing. Help is welcome!_