### PR TITLE
Add instructions to convert rollup example to TypeScript

### DIFF
--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -32,8 +32,7 @@ This example can also be used with TypeScript sources. The following steps conve
 3. Edit rollup.config.js
  1. Change the line `import commonjs from "@rollup/plugin-commonjs";` to `import typescript from "@rollup/plugin-typescript";`
  2. Change `input: "src/main.js",` to `input: "src/main.ts",`
- 3. Add `generatedCode: "es2015",` as an `output` parameter
- 4. Replace the `plugins` line `commonjs()` with `typescript()`
+ 3. Replace the `plugins` line `commonjs()` with `typescript()`
 4. Edit rollup.config.prod.js and make the same changes
 5. Add the file `tsconfig.json` to the folder containing `package.json`:
 ```json

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -25,15 +25,15 @@ This example can also be used with TypeScript sources. The following steps conve
 
 1. Rename src/main.js to src/main.ts
 2. Change npm packages
-	1. `npm uninstall -D @rollup/plugin-commonjs`
-	2. `npm install -D @rollup/plugin-typescript`
-	3. `npm install -D tslib`
-	4. `npm install -D typescript`
+ 1. `npm uninstall -D @rollup/plugin-commonjs`
+ 2. `npm install -D @rollup/plugin-typescript`
+ 3. `npm install -D tslib`
+ 4. `npm install -D typescript`
 3. Edit rollup.config.js
-	1. Change the line `import commonjs from "@rollup/plugin-commonjs";` to `import typescript from "@rollup/plugin-typescript";`
-	2. Change `input: "src/main.js",` to `input: "src/main.ts",`
-	3. Add `generatedCode: "es2015",` as an `output` parameter
-	4. Replace the `plugins` line `commonjs()` with `typescript()`
+ 1. Change the line `import commonjs from "@rollup/plugin-commonjs";` to `import typescript from "@rollup/plugin-typescript";`
+ 2. Change `input: "src/main.js",` to `input: "src/main.ts",`
+ 3. Add `generatedCode: "es2015",` as an `output` parameter
+ 4. Replace the `plugins` line `commonjs()` with `typescript()`
 4. Edit rollup.config.prod.js and make the same changes
 5. Add the file `tsconfig.json` to the folder containing `package.json`:
 ```json
@@ -53,7 +53,7 @@ This example can also be used with TypeScript sources. The following steps conve
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "target": "es2020"
   },
   "include": [
@@ -64,4 +64,4 @@ This example can also be used with TypeScript sources. The following steps conve
   ]
 }
 ```
-6. Use `npm run build` and `npm run build:prod` as before
+6. Use `npm run build` and `npm run build:prod` as before, but note that the watch feature of `npm run build` will not catch your TypeScript changes; you need to use `npm run watch` instead.

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -39,15 +39,13 @@ This example can also be used with TypeScript sources. The following steps conve
 ```json
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "declaration": false,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
-    "importsNotUsedAsValues": "preserve",
     "lib": ["dom", "es2020"],
-    "module": "esnext",
+    "module": "es2020",
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -19,3 +19,65 @@ For additional information, see the [Build with ES modules](https://developers.a
 ## Commands
 
 For a list of all available `npm` commands see the scripts in `package.json`.
+
+## TypeScript
+This example can also be used with TypeScript sources. The following steps convert the example into a TypeScript starter.
+
+1. Rename src/main.js to src/main.ts
+2. Change npm packages
+	1. `npm uninstall -D @rollup/plugin-commonjs`
+	2. `npm install -D @rollup/plugin-typescript`
+	3. `npm install -D tslib`
+	4. `npm install -D typescript`
+3. Edit rollup.config.js
+	1. Change the line `import commonjs from "@rollup/plugin-commonjs";` to `import typescript from "@rollup/plugin-typescript";`
+	2. Change `input: "src/main.js",` to `input: "src/main.ts",`
+	3. Add `generatedCode: "es2015",` as an `output` parameter
+	4. Replace the `plugins` line `commonjs()` with `typescript()`
+4. Edit rollup.config.prod.js and make the same changes
+5. Add the file `tsconfig.json` to the folder containing `package.json`:
+```json
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
+    "declaration": false,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "importsNotUsedAsValues": "preserve",
+    "lib": ["dom", "es2020"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "target": "es2020"
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}
+```
+6. Use `npm run build` and `npm run build:prod` as before
+
+Because TypeScript involves the extra step of transpilation, the watch feature doesn't appear to be possible, and so you might want to delete the following lines in rollup.config.js:
+```js
+import serve from "rollup-plugin-serve";
+import livereload from "rollup-plugin-livereload";
+serve("public"),
+livereload({
+  watch: "public/main.js"
+}),
+```
+and the following line in package.json: `"watch": "rollup -c -w"`
+(including the trailing comma on the previous line) and run
+```
+npm uninstall -D rollup-plugin-livereload
+npm uninstall -D rollup-plugin-serve
+```

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -65,19 +65,3 @@ This example can also be used with TypeScript sources. The following steps conve
 }
 ```
 6. Use `npm run build` and `npm run build:prod` as before
-
-Because TypeScript involves the extra step of transpilation, the watch feature doesn't appear to be possible, and so you might want to delete the following lines in rollup.config.js:
-```js
-import serve from "rollup-plugin-serve";
-import livereload from "rollup-plugin-livereload";
-serve("public"),
-livereload({
-  watch: "public/main.js"
-}),
-```
-and the following line in package.json: `"watch": "rollup -c -w"`
-(including the trailing comma on the previous line) and run
-```
-npm uninstall -D rollup-plugin-livereload
-npm uninstall -D rollup-plugin-serve
-```

--- a/esm-samples/rollup/rollup.config.js
+++ b/esm-samples/rollup/rollup.config.js
@@ -9,7 +9,8 @@ export default {
   output: {
     chunkFileNames: "chunks/[name]-[hash].js",
     dir: "public",
-    format: "es"
+    format: "es",
+    generatedCode: "es2015"
   },
   treeshake: false,
   plugins: [

--- a/esm-samples/rollup/rollup.config.prod.js
+++ b/esm-samples/rollup/rollup.config.prod.js
@@ -8,7 +8,8 @@ export default {
   output: {
     chunkFileNames: "chunks/[name]-[hash].js",
     dir: "public",
-    format: "es"
+    format: "es",
+    generatedCode: "es2015"
   },
   plugins: [
     del({ targets: ["public/chunks"], runOnce: true, verbose: true }),


### PR DESCRIPTION
As an alternative to a new example; see https://github.com/Esri/jsapi-resources/pull/363#issuecomment-1006839387