### PR TITLE
Update React sample browserslist

### DIFF
--- a/esm-samples/jsapi-create-react-app/package.json
+++ b/esm-samples/jsapi-create-react-app/package.json
@@ -26,9 +26,12 @@
   },
   "browserslist": {
     "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
+      "last 1 Chrome version",
+      "last 1 Firefox version",
+      "last 2 Edge major versions",
+      "last 2 Safari major versions",
+      "last 2 iOS major versions",
+      "Firefox ESR"
     ],
     "development": [
       "last 1 chrome version",


### PR DESCRIPTION
This PR updates the React sample's production browserslist to match the one used in the Angular sample. This will reduce both the initial load size and on-disk footprint. I left the dev browserslist alone, it's still using the CRA defaults. 