### PR TITLE
refactor(webpack, rollup): standardize jsapi code in esm samples

### DIFF
--- a/esm-samples/jsapi-create-react-app/src/App.js
+++ b/esm-samples/jsapi-create-react-app/src/App.js
@@ -4,7 +4,7 @@ import Expand from '@arcgis/core/widgets/Expand';
 import MapView from "@arcgis/core/views/MapView";
 import WebMap from "@arcgis/core/WebMap";
 
-import "./App.css"; 
+import "./App.css";
 
 function App() {
 

--- a/esm-samples/rollup/src/main.js
+++ b/esm-samples/rollup/src/main.js
@@ -1,189 +1,39 @@
 import Bookmarks from "@arcgis/core/widgets/Bookmarks";
-import DotDensityRenderer from "@arcgis/core/renderers/DotDensityRenderer";
 import Expand from "@arcgis/core/widgets/Expand";
-import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
-import Legend from "@arcgis/core/widgets/Legend";
 import MapView from "@arcgis/core/views/MapView";
-import WebMap from "@arcgis/core/WebMap"; 
+import WebMap from "@arcgis/core/WebMap";
 
-const map = new WebMap({
+const webmap = new WebMap({
   portalItem: {
-    id: "56b5bd522c52409c90d902285732e9f1",
-  },
+    id: "aa1d3f80270146208328cf66d022e09c"
+  }
 });
 
 const view = new MapView({
   container: "viewDiv",
-  map: map,
-  highlightOptions: {
-    fillOpacity: 0,
-    color: [50, 50, 50],
-  },
-  popup: {
-    dockEnabled: true,
-    dockOptions: {
-      position: "top-right",
-      breakpoint: false,
-    },
-  },
-  constraints: {
-    maxScale: 35000,
-  },
+  map: webmap
 });
 
-view.when().then(function () {
-  const dotDensityRenderer = new DotDensityRenderer({
-    dotValue: 100,
-    outline: null,
-    referenceScale: 577790, // 1:577,790 view scale
-    legendOptions: {
-      unit: "people",
-    },
-    attributes: [
-      {
-        field: "B03002_003E",
-        color: "#f23c3f",
-        label: "White (non-Hispanic)",
-      },
-      {
-        field: "B03002_012E",
-        color: "#e8ca0d",
-        label: "Hispanic",
-      },
-      {
-        field: "B03002_004E",
-        color: "#00b6f1",
-        label: "Black or African American",
-      },
-      {
-        field: "B03002_006E",
-        color: "#32ef94",
-        label: "Asian",
-      },
-      {
-        field: "B03002_005E",
-        color: "#ff7fe9",
-        label: "American Indian/Alaskan Native",
-      },
-      {
-        field: "B03002_007E",
-        color: "#e2c4a5",
-        label: "Pacific Islander/Hawaiian Native",
-      },
-      {
-        field: "B03002_008E",
-        color: "#ff6a00",
-        label: "Other race",
-      },
-      {
-        field: "B03002_009E",
-        color: "#96f7ef",
-        label: "Two or more races",
-      },
-    ],
-  });
+const bookmarks = new Bookmarks({
+  view,
+  // allows bookmarks to be added, edited, or deleted
+  editingEnabled: true
+});
 
-  // Add renderer to the layer and define a popup template
-  const url =
-    "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/ACS_Population_by_Race_and_Hispanic_Origin_Boundaries/FeatureServer/2";
-  const layer = new FeatureLayer({
-    url: url,
-    minScale: 20000000,
-    maxScale: 35000,
-    title: "Current Population Estimates (ACS)",
-    popupTemplate: {
-      title: "{County}, {State}",
-      content: [
-        {
-          type: "fields",
-          fieldInfos: [
-            {
-              fieldName: "B03002_003E",
-              label: "White (non-Hispanic)",
-              format: {
-                digitSeparator: true,
-                places: 0,
-              },
-            },
-            {
-              fieldName: "B03002_012E",
-              label: "Hispanic",
-              format: {
-                digitSeparator: true,
-                places: 0,
-              },
-            },
-            {
-              fieldName: "B03002_004E",
-              label: "Black or African American",
-              format: {
-                digitSeparator: true,
-                places: 0,
-              },
-            },
-            {
-              fieldName: "B03002_006E",
-              label: "Asian",
-              format: {
-                digitSeparator: true,
-                places: 0,
-              },
-            },
-            {
-              fieldName: "B03002_005E",
-              label: "American Indian/Alaskan Native",
-              format: {
-                digitSeparator: true,
-                places: 0,
-              },
-            },
-            {
-              fieldName: "B03002_007E",
-              label: "Pacific Islander/Hawaiian Native",
-              format: {
-                digitSeparator: true,
-                places: 0,
-              },
-            },
-            {
-              fieldName: "B03002_008E",
-              label: "Other race",
-              format: {
-                digitSeparator: true,
-                places: 0,
-              },
-            },
-            {
-              fieldName: "B03002_009E",
-              label: "Two or more races",
-              format: {
-                digitSeparator: true,
-                places: 0,
-              },
-            },
-          ],
-        },
-      ],
-    },
-    renderer: dotDensityRenderer,
-  });
+const bkExpand = new Expand({
+  view,
+  content: bookmarks,
+  expanded: true
+});
 
-  map.add(layer);
+// Add the widget to the top-right corner of the view
+view.ui.add(bkExpand, "top-right");
 
-  view.ui.add(
-    [
-      new Expand({
-        view: view,
-        content: new Legend({ view: view }),
-        group: "top-left",
-        expanded: true,
-      }),
-      new Expand({
-        view: view,
-        content: new Bookmarks({ view: view }),
-        group: "top-left",
-      }),
-    ],
-    "top-left"
-  );
+// bonus - how many bookmarks in the webmap?
+webmap.when(() => {
+  if (webmap.bookmarks && webmap.bookmarks.length) {
+    console.log("Bookmarks: ", webmap.bookmarks.length);
+  } else {
+    console.log("No bookmarks in this webmap.");
+  }
 });

--- a/esm-samples/webpack/src/index.js
+++ b/esm-samples/webpack/src/index.js
@@ -1,189 +1,39 @@
 import Bookmarks from "@arcgis/core/widgets/Bookmarks";
-import DotDensityRenderer from "@arcgis/core/renderers/DotDensityRenderer";
 import Expand from "@arcgis/core/widgets/Expand";
-import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
-import Legend from "@arcgis/core/widgets/Legend";
 import MapView from "@arcgis/core/views/MapView";
 import WebMap from "@arcgis/core/WebMap";
 
-const map = new WebMap({
+const webmap = new WebMap({
   portalItem: {
-    id: "56b5bd522c52409c90d902285732e9f1"
+    id: "aa1d3f80270146208328cf66d022e09c"
   }
 });
 
 const view = new MapView({
   container: "viewDiv",
-  map: map,
-  highlightOptions: {
-    fillOpacity: 0,
-    color: [50, 50, 50]
-  },
-  popup: {
-    dockEnabled: true,
-    dockOptions: {
-      position: "top-right",
-      breakpoint: false
-    }
-  },
-  constraints: {
-    maxScale: 35000
-  }
+  map: webmap
 });
 
-view.when().then(function () {
-  const dotDensityRenderer = new DotDensityRenderer({
-    dotValue: 100,
-    outline: null,
-    referenceScale: 577790, // 1:577,790 view scale
-    legendOptions: {
-      unit: "people"
-    },
-    attributes: [
-      {
-        field: "B03002_003E",
-        color: "#f23c3f",
-        label: "White (non-Hispanic)"
-      },
-      {
-        field: "B03002_012E",
-        color: "#e8ca0d",
-        label: "Hispanic"
-      },
-      {
-        field: "B03002_004E",
-        color: "#00b6f1",
-        label: "Black or African American"
-      },
-      {
-        field: "B03002_006E",
-        color: "#32ef94",
-        label: "Asian"
-      },
-      {
-        field: "B03002_005E",
-        color: "#ff7fe9",
-        label: "American Indian/Alaskan Native"
-      },
-      {
-        field: "B03002_007E",
-        color: "#e2c4a5",
-        label: "Pacific Islander/Hawaiian Native"
-      },
-      {
-        field: "B03002_008E",
-        color: "#ff6a00",
-        label: "Other race"
-      },
-      {
-        field: "B03002_009E",
-        color: "#96f7ef",
-        label: "Two or more races"
-      }
-    ]
-  });
+const bookmarks = new Bookmarks({
+  view,
+  // allows bookmarks to be added, edited, or deleted
+  editingEnabled: true
+});
 
-  // Add renderer to the layer and define a popup template
-  const url =
-    "https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/ACS_Population_by_Race_and_Hispanic_Origin_Boundaries/FeatureServer/2";
-  const layer = new FeatureLayer({
-    url: url,
-    minScale: 20000000,
-    maxScale: 35000,
-    title: "Current Population Estimates (ACS)",
-    popupTemplate: {
-      title: "{County}, {State}",
-      content: [
-        {
-          type: "fields",
-          fieldInfos: [
-            {
-              fieldName: "B03002_003E",
-              label: "White (non-Hispanic)",
-              format: {
-                digitSeparator: true,
-                places: 0
-              }
-            },
-            {
-              fieldName: "B03002_012E",
-              label: "Hispanic",
-              format: {
-                digitSeparator: true,
-                places: 0
-              }
-            },
-            {
-              fieldName: "B03002_004E",
-              label: "Black or African American",
-              format: {
-                digitSeparator: true,
-                places: 0
-              }
-            },
-            {
-              fieldName: "B03002_006E",
-              label: "Asian",
-              format: {
-                digitSeparator: true,
-                places: 0
-              }
-            },
-            {
-              fieldName: "B03002_005E",
-              label: "American Indian/Alaskan Native",
-              format: {
-                digitSeparator: true,
-                places: 0
-              }
-            },
-            {
-              fieldName: "B03002_007E",
-              label: "Pacific Islander/Hawaiian Native",
-              format: {
-                digitSeparator: true,
-                places: 0
-              }
-            },
-            {
-              fieldName: "B03002_008E",
-              label: "Other race",
-              format: {
-                digitSeparator: true,
-                places: 0
-              }
-            },
-            {
-              fieldName: "B03002_009E",
-              label: "Two or more races",
-              format: {
-                digitSeparator: true,
-                places: 0
-              }
-            }
-          ]
-        }
-      ]
-    },
-    renderer: dotDensityRenderer
-  });
+const bkExpand = new Expand({
+  view,
+  content: bookmarks,
+  expanded: true
+});
 
-  map.add(layer);
+// Add the widget to the top-right corner of the view
+view.ui.add(bkExpand, "top-right");
 
-  view.ui.add(
-    [
-      new Expand({
-        view: view,
-        content: new Legend({ view: view }),
-        group: "top-left",
-        expanded: true
-      }),
-      new Expand({
-        view: view,
-        content: new Bookmarks({ view: view }),
-        group: "top-left"
-      })
-    ],
-    "top-left"
-  );
+// bonus - how many bookmarks in the webmap?
+webmap.when(() => {
+  if (webmap.bookmarks && webmap.bookmarks.length) {
+    console.log("Bookmarks: ", webmap.bookmarks.length);
+  } else {
+    console.log("No bookmarks in this webmap.");
+  }
 });


### PR DESCRIPTION
Use the same jsapi code as the React, etc. samples for a one-to-one build size comparison. 