### PR TITLE
ci(metrics): skip workflow run on prs with draft label 

### DIFF
--- a/.github/workflows/analyze-builds.yml
+++ b/.github/workflows/analyze-builds.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 jobs:
   analyze:
-    if: github.event.label.name != 'draft'
+    if: contains(github.event.pull_request.labels.*.name, 'draft')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/analyze-builds.yml
+++ b/.github/workflows/analyze-builds.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 jobs:
   analyze:
-    if: contains(github.event.pull_request.labels.*.name, 'draft')
+    if: "!contains(github.event.pull_request.labels.*.name, 'draft')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/analyze-builds.yml
+++ b/.github/workflows/analyze-builds.yml
@@ -1,9 +1,11 @@
 name: ESM Sample Metrics
 on:
   pull_request:
+    types: [opened, reopened, synchronize, unlabeled]
     branches: [master]
 jobs:
   analyze:
+    if: github.event.label.name != 'draft'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Skips the metrics workflow run on PRs with the draft label. Samples are bumped ahead of time before the release occurs, so this will prevent the workflow from failing.