### PR TITLE
3x bower: update moment trees

### DIFF
--- a/3.x/bower/dojo/build.profile.js
+++ b/3.x/bower/dojo/build.profile.js
@@ -55,8 +55,8 @@ var profile = {
       location: "moment",
       main: "moment",
       trees: [
-          // don"t bother with .hidden, tests, min, src, and templates
-          [".", ".", /(\/\.)|(~$)|(test|txt|src|min|templates)/]
+        // don"t bother with .hidden, tests, min, src, and templates
+        [".", ".", /(\/\.)|(~$)|(dist|test|txt|src|min|templates|ts3.1-typing-tests|ts3.1-typing)/]
       ],
       resourceTags: {
         amd: function(filename, mid){

--- a/3.x/bower/dojo/package.json
+++ b/3.x/bower/dojo/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "postinstall": "bower install",
-    "build": "grunt build",
+    "build": "grunt build --force",
     "clean": "grunt clean"
   },
   "license": "Apache-2.0",

--- a/esm-samples/.metrics/4.23.0.csv
+++ b/esm-samples/.metrics/4.23.0.csv
@@ -1,6 +1,6 @@
 Sample,Build size (MB),Build file count,Main bundle file,Main bundle size (MB),Main bundle gzipped size (MB),Main bundle brotli compressed size (MB),Load time (ms), Total runtime (ms), Loaded size (MB), JS heap size (MB)
-Angular 13.2.5,7.99,212,main.05a3216974245eb5.js,1.67,0.47,0.38,7531,10869,5.24,21.65
-CRA 5.0.0,27.66,431,main.4e198c9c.js,1.68,0.46,0.37,6821,10073,5.13,20.98
-Vue 3.2.31,7.20,281,index.2de4fd1c.js,1.46,0.41,0.34,7642,10873,4.81,19.86
-Rollup 2.70.1,7.07,280,main.js,1.40,0.38,0.31,9072,12402,4.71,22.43
-Webpack 5.70.0,8.01,205,index.js,1.51,0.40,0.33,6671,9693,4.67,20.67
+Angular 13.2.5,7.99,212,main.d5ce15753c4dbfab.js,1.67,0.47,0.38,10469,13654,5.24,18.49
+CRA 5.0.0,27.67,431,main.656db1a3.js,1.68,0.46,0.37,5565,8719,5.13,22.61
+Vue 3.2.31,7.20,281,index.74f78054.js,1.46,0.41,0.34,4998,7777,4.82,19.60
+Rollup 2.70.1,7.08,280,main.js,1.40,0.38,0.31,6377,9479,4.74,19.19
+Webpack 5.70.0,8.02,205,index.js,1.51,0.40,0.33,5745,8466,4.95,18.10


### PR DESCRIPTION
Had to add some more folders to the `trees` to ignore in the Dojo build. The build throws a single random closure `JSC_SUSPICIOUS_SEMICOLON` warning, but treats it as an error, so had to add `--force` to the script. No runtime errors, but everything works.