### PR TITLE
ci(metrics): only run when package.json files are changed in esm-samples

### DIFF
--- a/.github/workflows/analyze-builds.yml
+++ b/.github/workflows/analyze-builds.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           # package.json files changed in the branch
-          packages_changed=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- "**/package.json")
+          packages_changed=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/master) -- "./esm-samples/**/package.json")
           # metric files changed in the previous commit
           metrics_changed=$(git diff --name-only HEAD^ HEAD -- "./esm-samples/.metrics/*.csv")
           if [ -z "$packages_changed" ]; then
@@ -38,7 +38,7 @@ jobs:
           node-version: lts/*
       - if: steps.build.outputs.skip == 'false'
         name: install dependencies for sample metrics script
-        run: | 
+        run: |
           cd ./.github/scripts/
           npm i
       - if: steps.build.outputs.skip == 'false'


### PR DESCRIPTION
Prevents the script from running when `package.json` files are changed in `3.x/...` such as #406