### PR TITLE
build(deps): bump samples to 4.24

### DIFF
--- a/esm-samples/jsapi-create-react-app/README.md
+++ b/esm-samples/jsapi-create-react-app/README.md
@@ -11,7 +11,7 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 _index.css_
 
 ```css
-@import "https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css";
+@import "https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css";
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.

--- a/esm-samples/jsapi-create-react-app/package.json
+++ b/esm-samples/jsapi-create-react-app/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.23.0",
-    "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^13.0.1",
-    "@testing-library/user-event": "^14.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "react-scripts": "^5.0.0",
+    "@arcgis/core": "^4.24.0",
+    "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react": "^13.3.0",
+    "@testing-library/user-event": "^14.2.0",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/esm-samples/jsapi-create-react-app/src/index.css
+++ b/esm-samples/jsapi-create-react-app/src/index.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 html,
 body,
 #root {

--- a/esm-samples/jsapi-node/package.json
+++ b/esm-samples/jsapi-node/package.json
@@ -1,16 +1,16 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.23.0",
+    "@arcgis/core": "^4.24.0",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.5",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-delete": "^2.0.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^21.0.2",
-    "@rollup/plugin-node-resolve": "^13.1.3",
-    "rollup": "^2.70.1"
+    "@rollup/plugin-commonjs": "^22.0.0",
+    "@rollup/plugin-node-resolve": "^13.3.0",
+    "rollup": "^2.75.6"
   },
   "scripts": {
     "build": "rollup -c"

--- a/esm-samples/jsapi-vue/README.md
+++ b/esm-samples/jsapi-vue/README.md
@@ -1,6 +1,6 @@
 # ArcGIS API for JavaScript with Vue and Vite
 
-This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with [Vite](https://vitejs.dev/guide/) using a [Vue.js](https://vuejs.org/) template. 
+This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with [Vite](https://vitejs.dev/guide/) using a [Vue.js](https://vuejs.org/) template.
 
 ## Get Started
 
@@ -11,7 +11,7 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 *main.css*
 
 ```css
-  @import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+  @import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
@@ -22,7 +22,7 @@ See the [VueJS Deployment](https://cli.vuejs.org/guide/deployment.html#deploymen
 
 ## Commands
 
-For a list of all available `npm` commands see the scripts in `package.json`. 
+For a list of all available `npm` commands see the scripts in `package.json`.
 
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/esm-samples/jsapi-vue/package.json
+++ b/esm-samples/jsapi-vue/package.json
@@ -7,11 +7,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "^4.23.0",
-    "vue": "^3.2.31"
+    "@arcgis/core": "^4.24.0",
+    "vue": "^3.2.37"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^2.2.4",
-    "vite": "^2.8.6"
+    "@vitejs/plugin-vue": "^2.3.3",
+    "vite": "^2.9.12"
   }
 }

--- a/esm-samples/jsapi-vue/src/main.css
+++ b/esm-samples/jsapi-vue/src/main.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 html,
 body,
 #app {

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -11,7 +11,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 *index.html*
 
 ```html
- <link rel="stylesheet" href="https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css>
+ <link rel="stylesheet" href="https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css>
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.

--- a/esm-samples/rollup/package.json
+++ b/esm-samples/rollup/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.23.0"
+    "@arcgis/core": "^4.24.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^21.0.2",
-    "@rollup/plugin-node-resolve": "^13.1.3",
-    "rollup": "^2.70.1",
+    "@rollup/plugin-commonjs": "^22.0.0",
+    "@rollup/plugin-node-resolve": "^13.3.0",
+    "rollup": "^2.75.6",
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-livereload": "^2.0.5",
     "rollup-plugin-serve": "^1.1.0",

--- a/esm-samples/rollup/public/index.html
+++ b/esm-samples/rollup/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Rollup Sample</title>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/dark/main.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/dark/main.css" />
     <style>
       html,
       body,

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -15,7 +15,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 *index.css*
 
 ```css
-@import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.

--- a/esm-samples/webpack/package.json
+++ b/esm-samples/webpack/package.json
@@ -1,17 +1,17 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.23.0"
+    "@arcgis/core": "^4.24.0"
   },
   "devDependencies": {
     "css-loader": "^6.7.1",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
     "mini-css-extract-plugin": "^2.6.0",
-    "source-map-loader": "^3.0.1",
-    "webpack": "^5.70.0",
-    "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.7.4"
+    "source-map-loader": "^4.0.0",
+    "webpack": "^5.73.0",
+    "webpack-cli": "^4.10.0",
+    "webpack-dev-server": "^4.9.2"
   },
   "scripts": {
     "build": "webpack --mode production",

--- a/esm-samples/webpack/src/index.css
+++ b/esm-samples/webpack/src/index.css
@@ -1,4 +1,4 @@
-@import "https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/dark/main.css";
+@import "https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/dark/main.css";
 html,
 body,
 #viewDiv {


### PR DESCRIPTION
Bumping the react, vue, webpack, rollup, and node samples for the 4.24 release