### PR TITLE
Update ESM samples for 4.24

### DIFF
--- a/.github/scripts/analyze-builds.js
+++ b/.github/scripts/analyze-builds.js
@@ -151,7 +151,7 @@ const execLogErr = async (command) => {
       const pageTotalMB = (perfResults.pageTotalBytes / 1024 ** 2).toFixed(2);
       const JSHeapUsedSizeMB = (perfResults.JSHeapUsedSizeBytes / 1024 ** 2).toFixed(2);
 
-      const output = `${sampleName} ${packageVersion},${buildSizeMB},${buildFileCount},${mainBundleName},${mainBundleSizeMB},${mainBundleSizeGzipMB},${mainBundleSizeBrotliMB},${perfResults.elapsedRuntimeMS},${perfResults.totalScriptTimeMS},${pageTotalMB},${JSHeapUsedSizeMB}\n`;
+      const output = `${sampleName} ${packageVersion},${buildSizeMB},${buildFileCount},${mainBundleName},${mainBundleSizeMB},${mainBundleSizeGzipMB},${mainBundleSizeBrotliMB},${perfResults.elapsedRuntimeMS},${perfResults.totalScriptTimeMS},${pageTotalMB},${perfResults.totalJSRequests},${JSHeapUsedSizeMB}\n`;
 
       console.log("Writing results to CSV:", output);
       stream.write(output);

--- a/.github/scripts/build-perf.js
+++ b/.github/scripts/build-perf.js
@@ -4,6 +4,7 @@ const WebServer = require("./WebServer");
 
 let go, webserver;
 let pageTotalBytes = 0;
+let totalJSRequests = 0;
 let performanceMarkStart, performanceMarkEnd;
 const PORT = 3000; // Used for both WebServer and TEST_URL
 const TEST_URL = "http://localhost:" + PORT;
@@ -13,6 +14,12 @@ const TEST_URL = "http://localhost:" + PORT;
  * @param {Object} response 
  */
 const addResponseSize = async (response) => {
+  const url = response.url();
+  const str = url.substring(url.length - 3, url.length);
+  if (str === ".js") {
+    totalJSRequests++;
+  }
+
   try {
     const buffer = await response.buffer();
     pageTotalBytes += buffer.length;
@@ -95,13 +102,15 @@ const capturePageMetrics = async (page, sampleName) => {
    * totalScriptTimeMS - approximate internal runtime of the library script in milliseconds.
    * Useful for comparing against the `elapsedRuntimeMS`. Should not be used as an indicator of
    * application performance, it's most useful for troubleshooting.
+   * totalJSRequests - total number of JavaScript files requested by the app
    */
   return {
     sampleName,
     elapsedRuntimeMS,
     pageTotalBytes,
     JSHeapUsedSizeBytes,
-    totalScriptTimeMS
+    totalScriptTimeMS,
+    totalJSRequests
   };
 };
 

--- a/.github/scripts/build-size.js
+++ b/.github/scripts/build-size.js
@@ -353,6 +353,8 @@ if (require.main === module) {
           performanceInfo.elapsedRuntimeMS,
           `\n --> script runtime (ms):`,
           performanceInfo.totalScriptTimeMS,
+          `\n --> total JS requests:`,
+          performanceInfo.totalJSRequests,
           `\n --> app load size:`,
           formatBytes(performanceInfo.pageTotalBytes, decimals, binary),
           `\n --> jsheap size:`,

--- a/.github/scripts/test-web-server.js
+++ b/.github/scripts/test-web-server.js
@@ -1,0 +1,20 @@
+const WebServer = require("./WebServer");
+const stdExec = require("child_process").exec;
+const exec = require("util").promisify(stdExec);
+
+let server;
+
+// Make sure you already built the appplication you are testing against :-)
+const run = () => {
+  const path = "../../esm-samples/jsapi-custom-widget/dist/";
+  server = new WebServer(path, 3000);
+  server.start();
+
+  setTimeout(async () => {
+    const t = await exec("cd " + path + " && cd .. && curl http://localhost:3000");  
+    console.log("Stopping", t);
+    server.stop();
+  }, 5000);
+}
+
+run();

--- a/esm-samples/.metrics/4.24.0.csv
+++ b/esm-samples/.metrics/4.24.0.csv
@@ -1,0 +1,6 @@
+Sample,Build size (MB),Build file count,Main bundle file,Main bundle size (MB),Main bundle gzipped size (MB),Main bundle brotli compressed size (MB),Load time (ms), Total runtime (ms), Loaded size (MB), JS heap size (MB)
+Angular 14.0.2,7.87,210,main.15bb0992e745c030.js,1.70,0.47,0.39,7824,11863,5.32,40,18.69
+CRA 5.0.1,27.53,425,main.b6e3e3c9.js,1.71,0.47,0.38,5028,10177,5.23,76,18.82
+Vue 3.2.37,7.14,287,index.0e2b5dcc.js,1.52,0.43,0.35,6036,9574,4.94,164,22.34
+Rollup 2.75.6,6.97,286,main.js,1.41,0.39,0.31,6880,10917,4.82,252,22.01
+Webpack 5.73.0,7.89,206,index.js,1.54,0.41,0.33,6601,10030,5.04,285,20.73

--- a/esm-samples/README.md
+++ b/esm-samples/README.md
@@ -1,6 +1,6 @@
 # @arcgis/core (ES modules)
 
-The sample projects in this directory demonstrate using [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with various frameworks, module bundlers and build tools. `@arcgis/core` is installed using NPM, and is intended for use in local builds that you host.
+The sample projects in this directory demonstrate using [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with various frameworks, module bundlers and build tools. `@arcgis/core` is installed using [NPM](https://docs.npmjs.com/downloading-and-installing-packages-locally), and is intended for use in local builds that you host.
 
 ### Get Started
 
@@ -19,4 +19,4 @@ The performance indicators will vary depending on the device or virtual machine 
 
 ### TypeScript
 
-For TypeScript users, the type definitions are included with the API. There is no need for a separate install.
+For TypeScript users, the type definitions are included when you install the API. There is no need for a separate install.

--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -1,11 +1,11 @@
 # ArcGIS API for JavaScript with Angular CLI
 
-This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with Angular 13. 
+This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with Angular. 
 
 ---
 ## Known issues
 
-* There is an optimization bug affecting production builds at Angular `12.2.x`. It is recommended to upgrade to Angular 13. For more information: https://github.com/Esri/feedback-js-api-next/issues/131.
+* There is an optimization bug affecting production builds at Angular `12.2.x`. It is recommended to upgrade to Angular 13+. For more information: https://github.com/Esri/feedback-js-api-next/issues/131.
 
 * If you are seeing `404` errors in the console after updating Angular `12.1.x` dependencies, you should try clearing your browser cache. This is an Angular caching issue. 
 
@@ -31,7 +31,7 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 *styles.css*
 
 ```css
-  @import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+  @import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.

--- a/esm-samples/jsapi-angular-cli/angular.json
+++ b/esm-samples/jsapi-angular-cli/angular.json
@@ -101,6 +101,5 @@
         }
       }
     }
-  },
-  "defaultProject": "jsapi-angular-cli"
+  }
 }

--- a/esm-samples/jsapi-angular-cli/package.json
+++ b/esm-samples/jsapi-angular-cli/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^14.0.2",
     "@angular/platform-browser-dynamic": "^14.0.2",
     "@angular/router": "^14.0.2",
-    "@arcgis/core": "^4.24.0-next.20220616",
+    "@arcgis/core": "^4.24.0",
     "rxjs": "~7.5.5",
     "tslib": "^2.4.0",
     "zone.js": "^0.11.6"

--- a/esm-samples/jsapi-angular-cli/package.json
+++ b/esm-samples/jsapi-angular-cli/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^14.0.2",
     "@angular/platform-browser-dynamic": "^14.0.2",
     "@angular/router": "^14.0.2",
-    "@arcgis/core": "^4.24.0",
+    "@arcgis/core": "~4.24.0",
     "rxjs": "~7.5.5",
     "tslib": "^2.4.0",
     "zone.js": "^0.11.6"

--- a/esm-samples/jsapi-angular-cli/package.json
+++ b/esm-samples/jsapi-angular-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jsapi-angular13-cli",
+  "name": "jsapi-angular14-cli",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
@@ -10,31 +10,31 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "~13.2.5",
-    "@angular/common": "~13.2.5",
-    "@angular/compiler": "~13.2.5",
-    "@angular/core": "~13.2.5",
-    "@angular/forms": "~13.2.5",
-    "@angular/platform-browser": "~13.2.5",
-    "@angular/platform-browser-dynamic": "~13.2.5",
-    "@angular/router": "~13.2.5",
-    "@arcgis/core": "^4.23.0",
-    "rxjs": "~7.4.0",
-    "tslib": "^2.3.0",
-    "zone.js": "~0.11.4"
+    "@angular/animations": "^14.0.2",
+    "@angular/common": "^14.0.2",
+    "@angular/compiler": "^14.0.2",
+    "@angular/core": "^14.0.2",
+    "@angular/forms": "^14.0.2",
+    "@angular/platform-browser": "^14.0.2",
+    "@angular/platform-browser-dynamic": "^14.0.2",
+    "@angular/router": "^14.0.2",
+    "@arcgis/core": "^4.24.0-next.20220616",
+    "rxjs": "~7.5.5",
+    "tslib": "^2.4.0",
+    "zone.js": "^0.11.6"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~13.2.5",
-    "@angular/cli": "~13.2.5",
-    "@angular/compiler-cli": "~13.2.5",
-    "@types/jasmine": "~3.10.0",
-    "@types/node": "^12.11.1",
-    "jasmine-core": "~3.10.0",
-    "karma": "~6.3.0",
-    "karma-chrome-launcher": "~3.1.0",
-    "karma-coverage": "~2.0.3",
-    "karma-jasmine": "~4.0.0",
-    "karma-jasmine-html-reporter": "~1.7.0",
-    "typescript": "~4.4.3"
+    "@angular-devkit/build-angular": "^14.0.2",
+    "@angular/cli": "^14.0.2",
+    "@angular/compiler-cli": "^14.0.2",
+    "@types/jasmine": "~4.0.3",
+    "@types/node": "^18.0.0",
+    "jasmine-core": "~4.2.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.1.1",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.0.0",
+    "typescript": "~4.7.3"
   }
 }

--- a/esm-samples/jsapi-angular-cli/src/app/app.component.css
+++ b/esm-samples/jsapi-angular-cli/src/app/app.component.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 .esri-view {
   padding: 0;
   margin: 0;

--- a/esm-samples/jsapi-angular-cli/src/app/app.component.ts
+++ b/esm-samples/jsapi-angular-cli/src/app/app.component.ts
@@ -50,9 +50,6 @@ export class AppComponent implements OnInit, OnDestroy {
 
     // Add the widget to the top-right corner of the view
     view.ui.add(bkExpand, 'top-right');
-    view.on("pointer-move", () => {
-      console.log("Click");
-    })
 
     // bonus - how many bookmarks in the webmap?
     webmap.when(() => {

--- a/esm-samples/jsapi-angular-cli/src/app/app.component.ts
+++ b/esm-samples/jsapi-angular-cli/src/app/app.component.ts
@@ -50,6 +50,9 @@ export class AppComponent implements OnInit, OnDestroy {
 
     // Add the widget to the top-right corner of the view
     view.ui.add(bkExpand, 'top-right');
+    view.on("pointer-move", () => {
+      console.log("Click");
+    })
 
     // bonus - how many bookmarks in the webmap?
     webmap.when(() => {

--- a/esm-samples/jsapi-angular-cli/tsconfig.json
+++ b/esm-samples/jsapi-angular-cli/tsconfig.json
@@ -16,7 +16,7 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2017",
+    "target": "es2020",
     "module": "es2020",
     "lib": [
       "es2020",

--- a/esm-samples/jsapi-create-react-app/README.md
+++ b/esm-samples/jsapi-create-react-app/README.md
@@ -11,7 +11,7 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 _index.css_
 
 ```css
-@import "https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css";
+@import "https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css";
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.

--- a/esm-samples/jsapi-create-react-app/package.json
+++ b/esm-samples/jsapi-create-react-app/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.23.0",
-    "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^13.0.1",
-    "@testing-library/user-event": "^14.0.0",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "react-scripts": "^5.0.0",
+    "@arcgis/core": "^4.24.0",
+    "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react": "^13.3.0",
+    "@testing-library/user-event": "^14.2.0",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/esm-samples/jsapi-create-react-app/package.json
+++ b/esm-samples/jsapi-create-react-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.24.0",
+    "@arcgis/core": "~4.24.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^14.2.0",

--- a/esm-samples/jsapi-create-react-app/src/index.css
+++ b/esm-samples/jsapi-create-react-app/src/index.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 html,
 body,
 #root {

--- a/esm-samples/jsapi-custom-widget/package.json
+++ b/esm-samples/jsapi-custom-widget/package.json
@@ -7,7 +7,7 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@arcgis/core": "^4.24.0",
+    "@arcgis/core": "~4.24.0",
     "typescript": "^4.7.3",
     "vite": "^2.9.12"
   }

--- a/esm-samples/jsapi-custom-widget/package.json
+++ b/esm-samples/jsapi-custom-widget/package.json
@@ -7,8 +7,8 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@arcgis/core": "^4.23.0",
-    "typescript": "^4.6.2",
-    "vite": "^2.8.6"
+    "@arcgis/core": "^4.24.0",
+    "typescript": "^4.7.3",
+    "vite": "^2.9.12"
   }
 }

--- a/esm-samples/jsapi-custom-widget/src/style.css
+++ b/esm-samples/jsapi-custom-widget/src/style.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 
 #viewDiv {
   padding: 0;

--- a/esm-samples/jsapi-custom-widget/src/widget.tsx
+++ b/esm-samples/jsapi-custom-widget/src/widget.tsx
@@ -1,5 +1,5 @@
 import { subclass, property } from "@arcgis/core/core/accessorSupport/decorators";
-import { init } from "@arcgis/core/core/watchUtils";
+import { watch } from "@arcgis/core/core/reactiveUtils";
 
 import { tsx, messageBundle } from "@arcgis/core/widgets/support/widget";
 
@@ -41,9 +41,19 @@ class Recenter extends Widget {
   }
 
   postInitialize() {
-    init(this, "view.center, view.interacting, view.scale", () =>
-      this._onViewChange()
-    );
+
+    // Set initial State
+    this.state = {
+      x: 0,
+      y: 0,
+      interacting: false,
+      scale: 0
+    };        
+
+    watch(() => [this.view?.center, this.view?.interacting],
+    () => {
+      this._onViewChange();
+    });
   }
 
   //--------------------------------------------------------------------

--- a/esm-samples/jsapi-custom-workers/package.json
+++ b/esm-samples/jsapi-custom-workers/package.json
@@ -1,22 +1,22 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.22.0"
+    "@arcgis/core": "^4.24.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^21.0.1",
-    "@rollup/plugin-node-resolve": "^13.1.3",
+    "@rollup/plugin-commonjs": "^22.0.0",
+    "@rollup/plugin-node-resolve": "^13.3.0",
     "css-loader": "^6.7.1",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
-    "mini-css-extract-plugin": "^2.6.0",
+    "mini-css-extract-plugin": "^2.6.1",
     "npm-run-all": "^4.1.5",
-    "rollup": "^2.70.1",
+    "rollup": "^2.75.6",
     "rollup-plugin-terser": "^7.0.2",
-    "source-map-loader": "^3.0.0",
-    "webpack": "^5.70.0",
-    "webpack-cli": "^4.9.1",
-    "webpack-dev-server": "^4.7.4"
+    "source-map-loader": "^4.0.0",
+    "webpack": "^5.73.0",
+    "webpack-cli": "^4.10.0",
+    "webpack-dev-server": "^4.9.2"
   },
   "scripts": {
     "build": "npm-run-all clean --parallel build:*",

--- a/esm-samples/jsapi-custom-workers/package.json
+++ b/esm-samples/jsapi-custom-workers/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.24.0"
+    "@arcgis/core": "~4.24.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/esm-samples/jsapi-custom-workers/src/index.css
+++ b/esm-samples/jsapi-custom-workers/src/index.css
@@ -1,4 +1,4 @@
-@import "https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/dark/main.css";
+@import "https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/dark/main.css";
 html,
 body,
 #viewDiv {

--- a/esm-samples/jsapi-custom-workers/src/index.js
+++ b/esm-samples/jsapi-custom-workers/src/index.js
@@ -3,7 +3,7 @@ import Graphic from "@arcgis/core/Graphic";
 import ArcGISMap from "@arcgis/core/Map";
 import MapView from "@arcgis/core/views/MapView";
 import FeatureLayer from "@arcgis/core/layers/FeatureLayer";
-import { whenFalseOnce } from "@arcgis/core/core/watchUtils";
+import { whenOnce } from "@arcgis/core/core/reactiveUtils";
 import * as colorRendererCreator from "@arcgis/core/smartMapping/renderers/color";
 import Legend from "@arcgis/core/widgets/Legend";
 import * as workers from "@arcgis/core/core/workers";
@@ -55,7 +55,7 @@ async function runJoin() {
     view.whenLayerView(cityLayer),
     view.whenLayerView(frsLayer)
   ]);
-  await whenFalseOnce(view, "updating");
+  await whenOnce(() => !view.updating);
   const query = {
     returnGeometry: true
   };
@@ -88,6 +88,7 @@ async function runJoin() {
 
   joinLayer.renderer = renderer;
   map.add(joinLayer);
+  console.log("Join complete");
 }
 
 async function createLayer(layer, source, extraFields) {

--- a/esm-samples/jsapi-esm-cdn/esm-cdn.html
+++ b/esm-samples/jsapi-esm-cdn/esm-cdn.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no" />
   <title>ArcGIS ESM CDN</title>
 
-  <link rel="stylesheet" href="https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css" />
+  <link rel="stylesheet" href="https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css" />
 
   <style>
     html,
@@ -19,10 +19,10 @@
     }
   </style>
   <script type="module">
-    import WebMap from 'https://js.arcgis.com/4.23/@arcgis/core/WebMap.js';
-    import MapView from 'https://js.arcgis.com/4.23/@arcgis/core/views/MapView.js';
-    import Bookmarks from 'https://js.arcgis.com/4.23/@arcgis/core/widgets/Bookmarks.js';
-    import Expand from 'https://js.arcgis.com/4.23/@arcgis/core/widgets/Expand.js';
+    import WebMap from 'https://js.arcgis.com/4.24/@arcgis/core/WebMap.js';
+    import MapView from 'https://js.arcgis.com/4.24/@arcgis/core/views/MapView.js';
+    import Bookmarks from 'https://js.arcgis.com/4.24/@arcgis/core/widgets/Bookmarks.js';
+    import Expand from 'https://js.arcgis.com/4.24/@arcgis/core/widgets/Expand.js';
 
     const webmap = new WebMap({
       portalItem: {

--- a/esm-samples/jsapi-node/package.json
+++ b/esm-samples/jsapi-node/package.json
@@ -1,16 +1,16 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.23.0",
+    "@arcgis/core": "^4.24.0",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.5",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-delete": "^2.0.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^21.0.2",
-    "@rollup/plugin-node-resolve": "^13.1.3",
-    "rollup": "^2.70.1"
+    "@rollup/plugin-commonjs": "^22.0.0",
+    "@rollup/plugin-node-resolve": "^13.3.0",
+    "rollup": "^2.75.6"
   },
   "scripts": {
     "build": "rollup -c"

--- a/esm-samples/jsapi-node/package.json
+++ b/esm-samples/jsapi-node/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.24.0",
+    "@arcgis/core": "~4.24.0",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.5",
     "rollup-plugin-copy": "^3.4.0",

--- a/esm-samples/jsapi-vue/README.md
+++ b/esm-samples/jsapi-vue/README.md
@@ -1,6 +1,6 @@
 # ArcGIS API for JavaScript with Vue and Vite
 
-This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with [Vite](https://vitejs.dev/guide/) using a [Vue.js](https://vuejs.org/) template. 
+This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with [Vite](https://vitejs.dev/guide/) using a [Vue.js](https://vuejs.org/) template.
 
 ## Get Started
 
@@ -11,7 +11,7 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 *main.css*
 
 ```css
-  @import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+  @import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
@@ -22,7 +22,7 @@ See the [VueJS Deployment](https://cli.vuejs.org/guide/deployment.html#deploymen
 
 ## Commands
 
-For a list of all available `npm` commands see the scripts in `package.json`. 
+For a list of all available `npm` commands see the scripts in `package.json`.
 
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/esm-samples/jsapi-vue/package.json
+++ b/esm-samples/jsapi-vue/package.json
@@ -7,11 +7,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "^4.23.0",
-    "vue": "^3.2.31"
+    "@arcgis/core": "^4.24.0",
+    "vue": "^3.2.37"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^2.2.4",
-    "vite": "^2.8.6"
+    "@vitejs/plugin-vue": "^2.3.3",
+    "vite": "^2.9.12"
   }
 }

--- a/esm-samples/jsapi-vue/package.json
+++ b/esm-samples/jsapi-vue/package.json
@@ -7,7 +7,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "^4.24.0",
+    "@arcgis/core": "~4.24.0",
     "vue": "^3.2.37"
   },
   "devDependencies": {

--- a/esm-samples/jsapi-vue/src/main.css
+++ b/esm-samples/jsapi-vue/src/main.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 html,
 body,
 #app {

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -11,7 +11,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 *index.html*
 
 ```html
- <link rel="stylesheet" href="https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css>
+ <link rel="stylesheet" href="https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css>
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.

--- a/esm-samples/rollup/package.json
+++ b/esm-samples/rollup/package.json
@@ -1,12 +1,12 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.23.0"
+    "@arcgis/core": "^4.24.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^21.0.2",
-    "@rollup/plugin-node-resolve": "^13.1.3",
-    "rollup": "^2.70.1",
+    "@rollup/plugin-commonjs": "^22.0.0",
+    "@rollup/plugin-node-resolve": "^13.3.0",
+    "rollup": "^2.75.6",
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-livereload": "^2.0.5",
     "rollup-plugin-serve": "^1.1.0",

--- a/esm-samples/rollup/package.json
+++ b/esm-samples/rollup/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.24.0"
+    "@arcgis/core": "~4.24.0"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/esm-samples/rollup/public/index.html
+++ b/esm-samples/rollup/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Rollup Sample</title>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/dark/main.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/dark/main.css" />
     <style>
       html,
       body,

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -15,7 +15,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 *index.css*
 
 ```css
-@import 'https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.

--- a/esm-samples/webpack/package.json
+++ b/esm-samples/webpack/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.24.0"
+    "@arcgis/core": "~4.24.0"
   },
   "devDependencies": {
     "css-loader": "^6.7.1",

--- a/esm-samples/webpack/package.json
+++ b/esm-samples/webpack/package.json
@@ -1,17 +1,17 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "^4.23.0"
+    "@arcgis/core": "^4.24.0"
   },
   "devDependencies": {
     "css-loader": "^6.7.1",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
     "mini-css-extract-plugin": "^2.6.0",
-    "source-map-loader": "^3.0.1",
-    "webpack": "^5.70.0",
-    "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.7.4"
+    "source-map-loader": "^4.0.0",
+    "webpack": "^5.73.0",
+    "webpack-cli": "^4.10.0",
+    "webpack-dev-server": "^4.9.2"
   },
   "scripts": {
     "build": "webpack --mode production",

--- a/esm-samples/webpack/src/index.css
+++ b/esm-samples/webpack/src/index.css
@@ -1,4 +1,4 @@
-@import "https://js.arcgis.com/4.23/@arcgis/core/assets/esri/themes/dark/main.css";
+@import "https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/dark/main.css";
 html,
 body,
 #viewDiv {


### PR DESCRIPTION
* Updates all the ESM samples to 4.24, except for Ember.
* Add the total number of JS requests to the build analysis tool.
* Notable changes:
  * Bumped Angular from v13 -> v14 
  * Angular TS target bumped from es2017 -> es2020
  * Upgraded several samples from `watchUtils` to `reactiveUtils`

