### PR TITLE
Add known issue about Webpack 4 and unexpected token errors

### DIFF
--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -5,10 +5,18 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 ## Known Issues
 - [July 2022] If you are using Webpack `4` and experiencing `Module parse failed: Unexpected token` errors during your build process after upgrading to ArcGIS API for JavaScript `4.24`+, then try the following steps. 
 
-  API version `4.24` is the first version to use ES2020 [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator). These steps can help resolve parsing errors with older versions of Webpack:
+  API version `4.24` is the first version to use ES2020 [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) operators. These steps can help resolve parsing errors with older versions of Webpack:
 
    - Install or upgrade these depedencies:
+
+   _Command-line_
+
+   ```
+     npm install -D @babel/core @babel/plugin-proposal-nullish-coalescing-operator @babel/plugin-proposal-optional-chaining babel-loader
+   ```
    
+   _package.json_
+
    ```json
     "@babel/core": "^7.18.9",
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
@@ -17,6 +25,8 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
    ```
 
    - Add the following to your Webpack config:
+
+   _webpack.config.js_
 
    ```
     module: {

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -15,7 +15,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
      npm install -D @babel/core @babel/plugin-proposal-nullish-coalescing-operator @babel/plugin-proposal-optional-chaining babel-loader
    ```
    
-     _package.json_
+    _package.json_
 
    ```json
     "@babel/core": "^7.18.9",
@@ -29,31 +29,31 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
      _webpack.config.js_
 
    ```
-    module: {
-      rules: [
-        {
-          test: /\.m?js$/,
-          exclude: {
-            and: [/node_modules/], // exclude libraries in node_modules ...
-            not: [
-              // except for ones that needs to be transpiled because they use modern syntax
-              /@arcgis[\\/]core/
-            ]
-          },
-          use: {
-            loader: "babel-loader",
-            options: {
-              plugins: [
-                // these are required by Webpack 4 since @arcgis/core@4.24
-                ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: true }],
-                ["@babel/plugin-proposal-optional-chaining", { loose: true }]
+      module: {
+        rules: [
+          {
+            test: /\.m?js$/,
+            exclude: {
+              and: [/node_modules/], // exclude libraries in node_modules ...
+              not: [
+                // except for ones that needs to be transpiled because they use modern syntax
+                /@arcgis[\\/]core/
               ]
+            },
+            use: {
+              loader: "babel-loader",
+              options: {
+                plugins: [
+                  // these are required by Webpack 4 since @arcgis/core@4.24
+                  ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: true }],
+                  ["@babel/plugin-proposal-optional-chaining", { loose: true }]
+                ]
+              }
             }
           }
-        }
-      ]
-    }
-  };
+        ]
+      }
+    };
    ```
 
 - `webpack-dev-server` had a [breaking change](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#-breaking-changes-4) in `4.0.0` which removed `contentBase` in favor of the `static` option. This sample has been changed accordingly.

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -5,8 +5,8 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 ## Known Issues
 - [July 2022] If you are using Webpack `4` and experiencing `Module parse failed: Unexpected token` errors during your build process after upgrading to ArcGIS API for JavaScript `4.24`+, then try the following steps. 
 
-  API version `4.24` is the first version to use [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator). These steps will help resolve the errors:
-  
+  API version `4.24` is the first version to use ES2020 [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator). These steps can help resolve parsing errors with older versions of Webpack:
+
    - Install or upgrade these depedencies:
    
    ```json

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -3,7 +3,9 @@
 This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) ES modules with webpack.
 
 ## Known Issues
-- [July 2022] If you are using Webpack `4`, and you recently upgraded to ArcGIS API for JavaScript `4.24`+ and experiencing `Module parse failed: Unexpected token` errors during your build process, then try the following steps. At API version `4.24` we introduced [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator), and these steps will help to resolve the errors:
+- [July 2022] If you are using Webpack `4` and experiencing `Module parse failed: Unexpected token` errors during your build process after upgrading to ArcGIS API for JavaScript `4.24`+, then try the following steps. 
+
+API version `4.24` is the first version to use [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator). These steps will help resolve the errors:
    - Install or upgrade these depedencies:
    
    ```json

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -15,7 +15,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
      npm install -D @babel/core @babel/plugin-proposal-nullish-coalescing-operator @babel/plugin-proposal-optional-chaining babel-loader
    ```
    
-    _package.json_
+     _package.json_
 
    ```json
     "@babel/core": "^7.18.9",

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -9,13 +9,13 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 
    - Install or upgrade these depedencies:
 
-   _Command-line_
+     _Command-line_
 
    ```
      npm install -D @babel/core @babel/plugin-proposal-nullish-coalescing-operator @babel/plugin-proposal-optional-chaining babel-loader
    ```
    
-   _package.json_
+     _package.json_
 
    ```json
     "@babel/core": "^7.18.9",
@@ -26,7 +26,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 
    - Add the following to your Webpack config:
 
-   _webpack.config.js_
+     _webpack.config.js_
 
    ```
     module: {

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -5,7 +5,8 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 ## Known Issues
 - [July 2022] If you are using Webpack `4` and experiencing `Module parse failed: Unexpected token` errors during your build process after upgrading to ArcGIS API for JavaScript `4.24`+, then try the following steps. 
 
-API version `4.24` is the first version to use [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator). These steps will help resolve the errors:
+  API version `4.24` is the first version to use [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator). These steps will help resolve the errors:
+  
    - Install or upgrade these depedencies:
    
    ```json

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -15,7 +15,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 
    - Add the following to your Webpack config:
 
-   ```json
+   ```
     module: {
       rules: [
         {

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -2,8 +2,47 @@
 
 This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) ES modules with webpack.
 
-
 ## Known Issues
+- [July 2022] If you are using Webpack `4`, and you recently upgraded to ArcGIS API for JavaScript `4.24`+ and experiencing `Module parse failed: Unexpected token` errors during your build process, then try the following steps. At API version `4.24` we introduced [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) and [nullish coalescing operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator), and these steps will help to resolve the errors:
+   - Install or upgrade these depedencies:
+   
+   ```json
+    "@babel/core": "^7.18.9",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
+    "@babel/plugin-proposal-optional-chaining": "^7.18.9",
+    "babel-loader": "^8.2.5",   
+   ```
+
+   - Add the following to your Webpack config:
+
+   ```json
+    module: {
+      rules: [
+        {
+          test: /\.m?js$/,
+          exclude: {
+            and: [/node_modules/], // exclude libraries in node_modules ...
+            not: [
+              // except for ones that needs to be transpiled because they use modern syntax
+              /@arcgis[\\/]core/
+            ]
+          },
+          use: {
+            loader: "babel-loader",
+            options: {
+              plugins: [
+                // these are required by Webpack 4 since @arcgis/core@4.24
+                ["@babel/plugin-proposal-nullish-coalescing-operator", { loose: true }],
+                ["@babel/plugin-proposal-optional-chaining", { loose: true }]
+              ]
+            }
+          }
+        }
+      ]
+    }
+  };
+   ```
+
 - `webpack-dev-server` had a [breaking change](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#-breaking-changes-4) in `4.0.0` which removed `contentBase` in favor of the `static` option. This sample has been changed accordingly.
 
 ## Get Started


### PR DESCRIPTION
This adds a new Known Issue note in the Webpack sample README. It provides information and a potential fix for users encountering unexpected token errors when using Webpack 4 with JS API v4.24+.