### PR TITLE
Update custom widget sample

### DIFF
--- a/esm-samples/.metrics/4.25.0.csv
+++ b/esm-samples/.metrics/4.25.0.csv
@@ -1,6 +1,6 @@
 Sample,Build size (MB),Build file count,Main bundle file,Main bundle size (MB),Main bundle gzipped size (MB),Main bundle brotli compressed size (MB),Load time (ms),Total runtime (ms),Loaded size (MB),Total JS requests,JS heap size (MB)
-Angular 14.2.8,8.29,234,main.acc60acdc4e3ff77.js,1.67,0.47,0.38,5209,8958,5.23,48,23.53
-React 18.2.0,7.62,323,index.ae304d8e.js,1.60,0.44,0.36,12233,15467,4.96,152,19.89
-Vue 3.2.41,7.53,323,index.21326ca5.js,1.51,0.42,0.34,5446,8822,4.88,256,21.55
-Rollup 3.2.5,7.34,322,main.js,1.39,0.38,0.30,6539,9295,4.74,360,16.94
-Webpack 5.74.0,8.34,240,index.js,1.52,0.40,0.32,5101,9154,4.96,401,17.58
+Angular 14.2.8,8.29,234,main.52c045e9d7613bdf.js,1.68,0.47,0.38,4385,8430,5.23,48,20.72
+React 18.2.0,7.62,323,index.9f9efe63.js,1.60,0.44,0.36,4684,7358,4.96,152,20.01
+Vue 3.2.41,7.53,323,index.ef64cf9b.js,1.51,0.42,0.34,4373,7261,4.88,256,23.02
+Rollup 3.2.5,7.34,322,main.js,1.39,0.38,0.31,4022,7573,4.74,360,18.77
+Webpack 5.74.0,8.34,240,index.js,1.52,0.40,0.32,4997,8360,4.96,401,18.39

--- a/esm-samples/jsapi-custom-widget/README.md
+++ b/esm-samples/jsapi-custom-widget/README.md
@@ -2,8 +2,12 @@
 
 This repo demonstrates creating a custom widget using [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with Vite. It also includes a basic example of using message bundles to display custom localized strings. 
 
+| :warning:  Deprecation Notice   |
+|-----------------------------------------|
+| This sample is deprecated and it will be removed in a future release. Refer to the [SDK's FAQ](https://developers.arcgis.com/javascript/latest/faq/#how-are-breaking-changes-managed) for more information on breaking changes. When building custom widgets, it is recommended to use the UI component library of your choice. |
+
 ## Known issues
-* Custom widgets currently do not work with Vite.js 3.
+* When using Vite 3, [`"useDefineForClassFields": false`](https://www.typescriptlang.org/tsconfig#useDefineForClassFields) needs to be set in `tsconfig.json`. The ArcGIS JS API requires this setting for the widget's property binding to work.
 
 ## Get Started
 

--- a/esm-samples/jsapi-custom-widget/package.json
+++ b/esm-samples/jsapi-custom-widget/package.json
@@ -7,7 +7,7 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@arcgis/core": "^4.25.1",
+    "@arcgis/core": "~4.25.0",
     "typescript": "^4.7.3",
     "vite": "^3.2.3"
   }

--- a/esm-samples/jsapi-custom-widget/package.json
+++ b/esm-samples/jsapi-custom-widget/package.json
@@ -7,8 +7,8 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@arcgis/core": "~4.25.0",
+    "@arcgis/core": "^4.25.1",
     "typescript": "^4.7.3",
-    "vite": "^2.9.12"
+    "vite": "^3.2.3"
   }
 }

--- a/esm-samples/jsapi-custom-widget/src/widget.tsx
+++ b/esm-samples/jsapi-custom-widget/src/widget.tsx
@@ -6,6 +6,9 @@ import { tsx, messageBundle } from "@arcgis/core/widgets/support/widget";
 import Point from "@arcgis/core/geometry/Point";
 import MapView from "@arcgis/core/views/MapView";
 import Widget from "@arcgis/core/widgets/Widget";
+// import WatchHandle from "@arcgis/core/core/Accessor";
+// import addHandles from "@arcgis/core/core/HandleOwner";
+import Handles from "@arcgis/core/core/Handles";
 
 type Coordinates = Point | number[] | any;
 
@@ -50,10 +53,16 @@ class Recenter extends Widget {
       scale: 0
     };        
 
-    watch(() => [this.view?.center, this.view?.interacting],
+    this._handle = new Handles();
+
+    this._handle.add(watch(() => [this.view?.center, this.view?.interacting],
     () => {
       this._onViewChange();
-    });
+    }));
+  }
+
+  destroy(): void {
+    this._handle.destroy();
   }
 
   //--------------------------------------------------------------------
@@ -94,6 +103,8 @@ class Recenter extends Widget {
   @property()
   @messageBundle("/esm-widget-vite/assets/t9n/widget")
   messages: { title: string; };
+
+  private _handle: Handles;
 
   //-------------------------------------------------------------------
   //

--- a/esm-samples/jsapi-custom-widget/src/widget.tsx
+++ b/esm-samples/jsapi-custom-widget/src/widget.tsx
@@ -6,8 +6,6 @@ import { tsx, messageBundle } from "@arcgis/core/widgets/support/widget";
 import Point from "@arcgis/core/geometry/Point";
 import MapView from "@arcgis/core/views/MapView";
 import Widget from "@arcgis/core/widgets/Widget";
-// import WatchHandle from "@arcgis/core/core/Accessor";
-// import addHandles from "@arcgis/core/core/HandleOwner";
 import Handles from "@arcgis/core/core/Handles";
 
 type Coordinates = Point | number[] | any;

--- a/esm-samples/jsapi-custom-widget/tsconfig.json
+++ b/esm-samples/jsapi-custom-widget/tsconfig.json
@@ -14,6 +14,7 @@
     "noImplicitReturns": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,        
+    "useDefineForClassFields": false,
     "jsx": "react",
     "jsxFactory": "tsx"  
   },


### PR DESCRIPTION
Includes the following updates for the Custom Widget sample:
- bumps sample to Vite 3
- add `"useDefineForClassFields": false` to tsconfig
- add Known Issue note about `useDefineForClassFields` setting is now required
- added handles to watcher
- add Deprecation Notice

cc @dasa @hgonzago 