### PR TITLE
Small update rollup samples

### DIFF
--- a/esm-samples/.metrics/4.25.0.csv
+++ b/esm-samples/.metrics/4.25.0.csv
@@ -1,6 +1,6 @@
 Sample,Build size (MB),Build file count,Main bundle file,Main bundle size (MB),Main bundle gzipped size (MB),Main bundle brotli compressed size (MB),Load time (ms),Total runtime (ms),Loaded size (MB),Total JS requests,JS heap size (MB)
-Angular 14.2.8,8.29,234,main.52c045e9d7613bdf.js,1.68,0.47,0.38,4385,8430,5.23,48,20.72
-React 18.2.0,7.62,323,index.9f9efe63.js,1.60,0.44,0.36,4684,7358,4.96,152,20.01
-Vue 3.2.41,7.53,323,index.ef64cf9b.js,1.51,0.42,0.34,4373,7261,4.88,256,23.02
-Rollup 3.2.5,7.34,322,main.js,1.39,0.38,0.31,4022,7573,4.74,360,18.77
-Webpack 5.74.0,8.34,240,index.js,1.52,0.40,0.32,4997,8360,4.96,401,18.39
+Angular 15.0.0,8.30,233,main.51db9017ec57cccd.js,1.68,0.47,0.38,9876,13666,5.24,48,26.35
+React 18.2.0,7.62,323,index.014717f4.js,1.60,0.44,0.36,5174,9330,4.97,152,25.19
+Vue 3.2.41,7.53,323,index.979a9297.js,1.51,0.42,0.34,5548,8838,4.88,256,21.86
+Rollup 3.10.1,7.61,482,index-9954d9d7.js,0.94,0.21,0.16,6273,10361,4.81,520,24.55
+Webpack 5.74.0,8.35,240,index.js,1.52,0.40,0.32,5134,10033,4.96,561,22.97

--- a/esm-samples/jsapi-custom-workers/README.md
+++ b/esm-samples/jsapi-custom-workers/README.md
@@ -3,7 +3,7 @@
 This repo demonstrates using [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) ES modules with custom workers.
 
 ## Known Issues
-- `@rollup/plugin-terser` has noticeably slower performance compared to `rollup-plugin-terser`. More information available on the [rollup](https://github.com/rollup/plugins/issues/1334) issue.
+- It is recommended to upgrade `@rollup/plugin-terser` to `v0.4.0` or later. Previous versions have noticeably slower performance compared to `rollup-plugin-terser`. More information is available in the plugin's [CHANGELOG](https://github.com/rollup/plugins/blob/master/packages/terser/CHANGELOG.md#v040).
 - `webpack-dev-server` had a [breaking change](https://github.com/webpack/webpack-dev-server/blob/master/CHANGELOG.md#-breaking-changes-4) in `4.0.0` which removed `contentBase` in favor of the `static` option. This sample has been changed accordingly.
 
 ## Building workers
@@ -15,7 +15,7 @@ The key to using custom workers is building the workers separately from your mai
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import terser from '@rollup/plugin-terser';
-
+[label](https://github.com/rollup/plugins/blob/master/packages/terser/CHANGELOG.md#rollupplugin-terser-changelog)
 const production = !process.env.ROLLUP_WATCH;
 
 export default {

--- a/esm-samples/jsapi-custom-workers/README.md
+++ b/esm-samples/jsapi-custom-workers/README.md
@@ -15,7 +15,7 @@ The key to using custom workers is building the workers separately from your mai
 import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import terser from '@rollup/plugin-terser';
-[label](https://github.com/rollup/plugins/blob/master/packages/terser/CHANGELOG.md#rollupplugin-terser-changelog)
+
 const production = !process.env.ROLLUP_WATCH;
 
 export default {

--- a/esm-samples/jsapi-custom-workers/package.json
+++ b/esm-samples/jsapi-custom-workers/package.json
@@ -1,21 +1,21 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "~4.24.7"
+    "@arcgis/core": "~4.25.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^23.0.2",
+    "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@rollup/plugin-terser": "^0.1.0",
-    "css-loader": "^6.7.1",
+    "@rollup/plugin-terser": "^0.4.0",
+    "css-loader": "^6.7.3",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
-    "mini-css-extract-plugin": "^2.6.1",
+    "mini-css-extract-plugin": "^2.7.2",
     "npm-run-all": "^4.1.5",
-    "rollup": "^3.2.5",
+    "rollup": "^3.10.1",
     "source-map-loader": "^4.0.1",
-    "webpack": "^5.74.0",
-    "webpack-cli": "^4.10.0",
+    "webpack": "^5.75.0",
+    "webpack-cli": "^5.0.1",
     "webpack-dev-server": "^4.11.1"
   },
   "scripts": {

--- a/esm-samples/jsapi-custom-workers/src/index.css
+++ b/esm-samples/jsapi-custom-workers/src/index.css
@@ -1,4 +1,4 @@
-@import "https://js.arcgis.com/4.24/@arcgis/core/assets/esri/themes/dark/main.css";
+@import "https://js.arcgis.com/4.25/@arcgis/core/assets/esri/themes/dark/main.css";
 html,
 body,
 #viewDiv {

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -2,6 +2,9 @@
 
 This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) ES modules with rollup.
 
+## Known Issues
+- It is recommended to upgrade `@rollup/plugin-terser` to `v0.4.0` or later. Previous versions have noticeably slower performance compared to `rollup-plugin-terser`. More information is available in the plugin's [CHANGELOG](https://github.com/rollup/plugins/blob/master/packages/terser/CHANGELOG.md#v040).
+
 ## Get Started
 
 **Step 1** - Run `npm install` and then start adding modules

--- a/esm-samples/rollup/package.json
+++ b/esm-samples/rollup/package.json
@@ -5,13 +5,13 @@
     "@arcgis/core": "~4.25.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^23.0.2",
+    "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@rollup/plugin-terser": "~0.1.0",
-    "rollup": "^3.2.5",
+    "@rollup/plugin-terser": "~0.4.0",
+    "rollup": "^3.10.1",
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-livereload": "^2.0.5",
-    "rollup-plugin-serve": "^2.0.1"
+    "rollup-plugin-serve": "^2.0.2"
   },
   "scripts": {
     "start": "rollup -c rollup.config.js",

--- a/esm-samples/webpack/public/index.html
+++ b/esm-samples/webpack/public/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no">    
     <title>Webpack | Bookmarks widget</title>
   </head>
   <body>


### PR DESCRIPTION
Updated jsapi-custom-workers and rollup samples. Primary reason was to upgrade `@rollup/plugin-terser` to `v0.4.0` for performance reasons. 

Also updated the webpack sample's `index.html` to include a viewport meta tag.

