### PR TITLE
Install babel-loader v8

### DIFF
--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -12,7 +12,7 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
      _Command-line_
 
    ```
-     npm install -D @babel/core @babel/plugin-proposal-nullish-coalescing-operator @babel/plugin-proposal-optional-chaining babel-loader
+     npm install -D @babel/core @babel/plugin-proposal-nullish-coalescing-operator @babel/plugin-proposal-optional-chaining babel-loader@8
    ```
    
      _package.json_


### PR DESCRIPTION
if you don't specify `@8` then you'll get v9 which doesn't work w/ webpack 4:

https://github.com/babel/babel-loader#install