### PR TITLE
Fix reporting of totalJSRequests in ESM build stats

### DIFF
--- a/.github/scripts/build-perf.js
+++ b/.github/scripts/build-perf.js
@@ -134,6 +134,7 @@ const startWebServer = (path, port) => {
  */
 const browserPerformanceTest = async (path, sampleName = "") => {
   pageTotalBytes = 0;
+  totalJSRequests = 0;
   startWebServer(path, PORT);
 
   const browser = await puppeteer.launch({ headless: true });
@@ -151,11 +152,17 @@ const browserPerformanceTest = async (path, sampleName = "") => {
 
   // Check for HTTP page not found errors
   if (go?.status() !== 404) {
-    // Did the root CSS for the View get injected into the DOM
-    await page.waitForSelector(".esri-view-root");
-    console.log("Page loaded. Capturing metrics...");
-
-    const pageMetrics = await capturePageMetrics(page, sampleName);
+    await page.waitForSelector(".esri-view-root")
+    .then( async () => {
+      console.log("waitForSelector SUCCESS.");
+      console.log("Pause for any additional http responses.");
+      await new Promise(r => setTimeout(r, 10000));         
+      console.log("Page loaded. Capturing metrics...");
+      pageMetrics = await capturePageMetrics(page, sampleName);
+    })
+    .catch((err) => {
+      console.error("waitForSelector timeout ERROR: ", err);
+    });
 
     // Clean up by closing the browser
     await browser.close();
@@ -173,5 +180,5 @@ const browserPerformanceTest = async (path, sampleName = "") => {
     };
   }
 };
-
+// browserPerformanceTest("../../esm-samples/webpack/dist/","Webpack");
 module.exports = browserPerformanceTest;

--- a/.github/scripts/build-perf.js
+++ b/.github/scripts/build-perf.js
@@ -180,5 +180,5 @@ const browserPerformanceTest = async (path, sampleName = "") => {
     };
   }
 };
-// browserPerformanceTest("../../esm-samples/webpack/dist/","Webpack");
+
 module.exports = browserPerformanceTest;

--- a/esm-samples/.metrics/4.26.5.csv
+++ b/esm-samples/.metrics/4.26.5.csv
@@ -1,0 +1,6 @@
+Sample,Build size (MB),Build file count,Main bundle file,Main bundle size (MB),Main bundle gzipped size (MB),Main bundle brotli compressed size (MB),Load time (ms),Total runtime (ms),Loaded size (MB),Total JS requests,JS heap size (MB)
+Angular 15.1.5,8.38,241,main.cf12fd3fdc5debd6.js,1.79,0.50,0.41,6896,21109,5.44,50,24.10
+React 18.2.0,7.50,359,index-860b05d2.js,1.69,0.47,0.38,7189,20276,5.05,125,24.94
+Vue 3.2.47,7.41,359,index-d5f29cc5.js,1.61,0.45,0.36,7029,19887,4.97,125,21.01
+Rollup 3.17.2,7.24,358,main.js,1.49,0.41,0.33,7164,20087,4.83,125,21.37
+Webpack 5.75.0,8.40,249,index.js,1.63,0.44,0.35,7740,21391,5.13,43,24.54

--- a/esm-samples/jsapi-angular-cli/package.json
+++ b/esm-samples/jsapi-angular-cli/package.json
@@ -18,7 +18,7 @@
     "@angular/platform-browser": "^15.1.5",
     "@angular/platform-browser-dynamic": "^15.1.5",
     "@angular/router": "^15.1.5",
-    "@arcgis/core": "~4.26.0",
+    "@arcgis/core": "~4.26.5",
     "rxjs": "~7.8.0",
     "tslib": "^2.5.0",
     "zone.js": "^0.12.0"

--- a/esm-samples/jsapi-custom-widget/package.json
+++ b/esm-samples/jsapi-custom-widget/package.json
@@ -7,7 +7,7 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "@arcgis/core": "~4.26.0",
+    "@arcgis/core": "~4.26.5",
     "typescript": "^4.9.5",
     "vite": "^4.1.2"
   }

--- a/esm-samples/jsapi-custom-workers/package.json
+++ b/esm-samples/jsapi-custom-workers/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "devDependencies": {
-    "@arcgis/core": "~4.26.0",    
+    "@arcgis/core": "~4.26.5",    
     "@rollup/plugin-commonjs": "^24.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-terser": "^0.4.0",

--- a/esm-samples/jsapi-node/package.json
+++ b/esm-samples/jsapi-node/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "~4.26.0",
+    "@arcgis/core": "~4.26.5",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.5",
     "rollup-plugin-copy": "^3.4.0",

--- a/esm-samples/jsapi-react/package.json
+++ b/esm-samples/jsapi-react/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "~4.26.0",
+    "@arcgis/core": "^4.26.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/esm-samples/jsapi-vue/package.json
+++ b/esm-samples/jsapi-vue/package.json
@@ -7,7 +7,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "~4.26.0",
+    "@arcgis/core": "~4.26.5",
     "vue": "^3.2.47"
   },
   "devDependencies": {

--- a/esm-samples/rollup/package.json
+++ b/esm-samples/rollup/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@arcgis/core": "~4.26.0"
+    "@arcgis/core": "~4.26.5"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.1",

--- a/esm-samples/webpack/package.json
+++ b/esm-samples/webpack/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "~4.26.0"
+    "@arcgis/core": "~4.26.5"
   },
   "devDependencies": {
     "css-loader": "^6.7.3",


### PR DESCRIPTION
The ESM build stats were incorrectly reporting the `totalJSRequests` metric. This number represents the total number of JavaScript files requests by each sample that is tested. A bug was preventing the value from resetting to zero between tests, which resulted in the number being calculated cumulatively. 

This fix applies to all new updates going forward. At this time, it does not update test results for previous versions. 

Reference: https://github.com/Esri/jsapi-resources/tree/main/esm-samples/.metrics  