### PR TITLE
Node.js sample - remove polyfills

### DIFF
--- a/esm-samples/.metrics/4.26.5.csv
+++ b/esm-samples/.metrics/4.26.5.csv
@@ -1,6 +1,6 @@
 Sample,Build size (MB),Build file count,Main bundle file,Main bundle size (MB),Main bundle gzipped size (MB),Main bundle brotli compressed size (MB),Load time (ms),Total runtime (ms),Loaded size (MB),Total JS requests,JS heap size (MB)
-Angular 15.1.5,8.38,241,main.cf12fd3fdc5debd6.js,1.79,0.50,0.41,6896,21109,5.44,50,24.10
-React 18.2.0,7.50,359,index-860b05d2.js,1.69,0.47,0.38,7189,20276,5.05,125,24.94
-Vue 3.2.47,7.41,359,index-d5f29cc5.js,1.61,0.45,0.36,7029,19887,4.97,125,21.01
-Rollup 3.17.2,7.24,358,main.js,1.49,0.41,0.33,7164,20087,4.83,125,21.37
-Webpack 5.75.0,8.40,249,index.js,1.63,0.44,0.35,7740,21391,5.13,43,24.54
+Angular 15.1.5,8.38,241,main.f6007007c73f16bf.js,1.79,0.50,0.41,6714,20799,5.44,50,26.16
+React 18.2.0,7.50,359,index-2ad1b7dd.js,1.69,0.47,0.39,7641,20654,5.05,125,24.45
+Vue 3.2.47,7.41,359,index-1c78af71.js,1.61,0.45,0.36,5490,19065,4.97,125,19.98
+Rollup 3.17.2,7.24,358,main.js,1.49,0.41,0.33,6369,19950,4.82,125,22.32
+Webpack 5.75.0,8.40,249,index.js,1.63,0.44,0.35,4811,20611,5.13,43,21.96

--- a/esm-samples/.metrics/4.26.5.csv
+++ b/esm-samples/.metrics/4.26.5.csv
@@ -1,6 +1,6 @@
 Sample,Build size (MB),Build file count,Main bundle file,Main bundle size (MB),Main bundle gzipped size (MB),Main bundle brotli compressed size (MB),Load time (ms),Total runtime (ms),Loaded size (MB),Total JS requests,JS heap size (MB)
-Angular 15.1.5,8.38,241,main.f6007007c73f16bf.js,1.79,0.50,0.41,6714,20799,5.44,50,26.16
-React 18.2.0,7.50,359,index-2ad1b7dd.js,1.69,0.47,0.39,7641,20654,5.05,125,24.45
-Vue 3.2.47,7.41,359,index-1c78af71.js,1.61,0.45,0.36,5490,19065,4.97,125,19.98
-Rollup 3.17.2,7.24,358,main.js,1.49,0.41,0.33,6369,19950,4.82,125,22.32
-Webpack 5.75.0,8.40,249,index.js,1.63,0.44,0.35,4811,20611,5.13,43,21.96
+Angular 15.1.5,8.38,241,main.f6007007c73f16bf.js,1.79,0.50,0.41,6354,19723,5.44,50,22.19
+React 18.2.0,7.50,359,index-2ad1b7dd.js,1.69,0.47,0.39,5345,19385,5.05,125,25.47
+Vue 3.2.47,7.41,359,index-1c78af71.js,1.61,0.45,0.36,7144,20105,4.97,125,24.56
+Rollup 3.17.2,7.24,358,main.js,1.49,0.41,0.33,7580,21194,4.82,125,24.36
+Webpack 5.75.0,8.40,249,index.js,1.63,0.44,0.35,7003,20286,5.13,43,23.53

--- a/esm-samples/jsapi-node/README.md
+++ b/esm-samples/jsapi-node/README.md
@@ -3,7 +3,7 @@
 Integrating Node.js with [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) can be done by building the app with [native ES modules in a supported Node version](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html) or by transpiling to CommonJS. This sample contains examples of both approaches.
 
 ## Known Issues
-* Working with `fetch` - Use Node 18+, or with earlier versions use the `--experiment-fetch` flag. For example, use `node --experimental-fetch test-request.js`. For more information see the [Node.js 18 release notes](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental).
+* A note about `fetch` - The Maps SDK uses the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) internally. To accommodate this, use Node 18+, or with earlier versions use the `--experiment-fetch` flag. For example, `node --experimental-fetch test-request.js`. For more information see the [Node.js 18 release notes](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental).
 
 ## Working with assets
 

--- a/esm-samples/jsapi-node/README.md
+++ b/esm-samples/jsapi-node/README.md
@@ -3,6 +3,7 @@
 Integrating Node.js with [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) can be done by building the app with [native ES modules in a supported Node version](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html) or by transpiling to CommonJS. This sample contains examples of both approaches.
 
 ## Known Issues
+
 * A note about `fetch` - The Maps SDK uses the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) internally. To accommodate this, use Node 18+, or with earlier versions use the `--experiment-fetch` flag. For example, `node --experimental-fetch test-request.js`. For more information see the [Node.js 18 release notes](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental).
 
 ## Working with assets

--- a/esm-samples/jsapi-node/README.md
+++ b/esm-samples/jsapi-node/README.md
@@ -2,6 +2,9 @@
 
 Integrating Node.js with [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) can be done by building the app with [native ES modules in a supported Node version](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html) or by transpiling to CommonJS. This sample contains examples of both approaches.
 
+## Known Issues
+* Working with `fetch` - Use Node 18+, or with earlier versions use the `--experiment-fetch` flag. For example, use `node --experimental-fetch test-request.js`. For more information see the [Node.js 18 release notes](https://nodejs.org/en/blog/announcements/v18-release-announce#fetch-experimental).
+
 ## Working with assets
 
 For most local builds, the API's assets are pulled from the ArcGIS CDN at runtime and there is no need for additional configuration. However, when working with certain modules, Node.js may require configuring the API to manage the assets locally. The assets include images, web workers, web assembly and localization files. Be sure to set [`config.assetsPath`](https://developers.arcgis.com/javascript/latest/api-reference/esri-config.html#assetsPath) so that the assets are correctly resolved, for example:
@@ -14,15 +17,6 @@ esriConfig.assetsPath = "node_modules/@arcgis/core/assets"; // relative to when 
 An example can be found in [`projection.js`](https://github.com/Esri/jsapi-resources/blob/master/esm-samples/jsapi-node/src/projection.js#L6).
 
 More information can be found in the [Working with assets](https://developers.arcgis.com/javascript/latest/es-modules/#working-with-assets) guide topic.
-
-## Polyfills
-
-Because Node does not have a native `fetch` or `abort-controller`, you will need to load polyfills:
-
-```js
-require("cross-fetch/polyfill");
-require("abort-controller/polyfill");
-```
 
 An example can be found in the [test-webmap.js](https://github.com/Esri/jsapi-resources/blob/master/esm-samples/jsapi-node/test-webmap.js#L4-L5) file.
 

--- a/esm-samples/jsapi-node/native-esm/request.mjs
+++ b/esm-samples/jsapi-node/native-esm/request.mjs
@@ -1,9 +1,5 @@
 #!/usr/bin/env node
 
-// load `fetch` and AbortController polyfills
-import "cross-fetch/dist/node-polyfill.js";
-import "abort-controller/polyfill.js"; // polyfill.mjs doesn't work since extensions are missing in abort-controller code
-
 import esriConfig from "@arcgis/core/config.js";
 import esriRequest from "@arcgis/core/request.js";
 

--- a/esm-samples/jsapi-node/native-esm/webmap.mjs
+++ b/esm-samples/jsapi-node/native-esm/webmap.mjs
@@ -1,9 +1,5 @@
 #!/usr/bin/env node
 
-// load `fetch` and AbortController polyfills
-import "cross-fetch/dist/node-polyfill.js";
-import "abort-controller/polyfill.js"; // polyfill.mjs doesn't work since extensions are missing in abort-controller code
-
 import esriConfig from "@arcgis/core/config.js";
 import WebMap from "@arcgis/core/WebMap.js";
 

--- a/esm-samples/jsapi-node/package.json
+++ b/esm-samples/jsapi-node/package.json
@@ -2,8 +2,6 @@
   "private": true,
   "dependencies": {
     "@arcgis/core": "~4.26.5",
-    "abort-controller": "^3.0.0",
-    "cross-fetch": "^3.1.5",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-delete": "^2.0.0"
   },

--- a/esm-samples/jsapi-node/test-request.js
+++ b/esm-samples/jsapi-node/test-request.js
@@ -1,6 +1,3 @@
 #!/usr/bin/env node
 
-// load `fetch` and AbortController polyfills
-require("cross-fetch/polyfill");
-require("abort-controller/polyfill");
 require("./public/request");

--- a/esm-samples/jsapi-node/test-webmap.js
+++ b/esm-samples/jsapi-node/test-webmap.js
@@ -1,6 +1,3 @@
 #!/usr/bin/env node
 
-// load `fetch` and AbortController polyfills
-require("cross-fetch/polyfill");
-require("abort-controller/polyfill");
 require("./public/webmap");


### PR DESCRIPTION
Remove polyfills from `jsapi-node` sample and update README:
- `cross-fetch` appears to be unmaintained.
- `abort-controller` is supported as of Node 15.0.
- `fetch` is included in Node 18

cc @odoe 