### PR TITLE
chore(sample): various updates to the AMD TS demo app

### DIFF
--- a/4.x/typescript/README.md
+++ b/4.x/typescript/README.md
@@ -1,11 +1,13 @@
 # TypeScript
 
-The [arcgis-js-api.d.ts](arcgis-js-api.d.ts) file provides type definitions for ArcGIS Maps SDK for JavaScript.
+The [arcgis-js-api.d.ts](arcgis-js-api.d.ts) file provides type definitions for ArcGIS Maps SDK for JavaScript when using AMD modules and it can be downloaded from this repo.
 
-A copy of this file is also available at [DefinitelyTyped][1] and may be installed using the command:  
-`npm install --save @types/arcgis-js-api`
+A copy of this file is also currently available at [DefinitelyTyped][1] and may be installed using the command:  
+`npm install --save @types/arcgis-js-api`.
 
-Currently, due to limitations in TypeScript, the APIs [autocasting](https://developers.arcgis.com/javascript/latest/programming-patterns/#autocasting) functionality works best in non-TypeScript applications. No changes are required if you are already using the API without any TypeScript build errors.
+## Known issues
+
+* Currently, due to limitations in TypeScript, the APIs [autocasting](https://developers.arcgis.com/javascript/latest/programming-patterns/#autocasting) functionality works best in non-TypeScript applications. No changes are required if you are already using the API without any TypeScript build errors.
 
 ## Requirements
 
@@ -15,6 +17,23 @@ Currently, due to limitations in TypeScript, the APIs [autocasting](https://deve
 
 * [TypeScript Editor Support][3]
 * Type definitions for many other libraries are available [here][4].
+
+## Licensing
+Copyright 2023 Esri
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+A copy of the license is available in the repository's [license.txt](https://github.com/Esri/jsapi-resources/blob/master/license.txt) file.
 
 [1]: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/arcgis-js-api
 [2]: http://www.typescriptlang.org/

--- a/4.x/typescript/README.md
+++ b/4.x/typescript/README.md
@@ -1,6 +1,6 @@
 # TypeScript
 
-The [arcgis-js-api.d.ts](arcgis-js-api.d.ts) file provides TypeScript type definitions for ArcGIS Maps SDK for JavaScript when using AMD modules. 
+The [arcgis-js-api.d.ts](arcgis-js-api.d.ts) file provides TypeScript type definitions for the ArcGIS Maps SDK for JavaScript's AMD modules.
 
 The `.d.ts` declaration file only provides type information and can be downloaded from this repo. A copy of the file is also currently available at [DefinitelyTyped][1] and may be installed using the command:  
 `npm install --save @types/arcgis-js-api`.

--- a/4.x/typescript/README.md
+++ b/4.x/typescript/README.md
@@ -1,13 +1,15 @@
 # TypeScript
 
-The [arcgis-js-api.d.ts](arcgis-js-api.d.ts) file provides type definitions for ArcGIS Maps SDK for JavaScript when using AMD modules and it can be downloaded from this repo.
+The [arcgis-js-api.d.ts](arcgis-js-api.d.ts) file provides TypeScript type definitions for ArcGIS Maps SDK for JavaScript when using AMD modules. 
 
-A copy of this file is also currently available at [DefinitelyTyped][1] and may be installed using the command:  
+The `.d.ts` declaration file only provides type information and can be downloaded from this repo. A copy of the file is also currently available at [DefinitelyTyped][1] and may be installed using the command:  
 `npm install --save @types/arcgis-js-api`.
+
+If you are looking to locally install the SDK library, which contains the full SDK functionality along with the type definitions, then refer to the SDK's [Introduction to tooling](https://developers.arcgis.com/javascript/latest/tooling-intro/) guide topic.
 
 ## Known issues
 
-* Currently, due to limitations in TypeScript, the APIs [autocasting](https://developers.arcgis.com/javascript/latest/programming-patterns/#autocasting) functionality works best in non-TypeScript applications. No changes are required if you are already using the API without any TypeScript build errors.
+* Currently, due to limitations in TypeScript, the APIs [autocasting](https://developers.arcgis.com/javascript/latest/programming-patterns/#autocasting) functionality works best in non-TypeScript applications. No changes are required if you are already using the SDK without any TypeScript build errors.
 
 ## Requirements
 

--- a/4.x/typescript/demo/README.md
+++ b/4.x/typescript/demo/README.md
@@ -1,9 +1,9 @@
-# Demo App
+# Demo App (AMD)
 
-> TypeScript with the [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/)
+A simple application that demonstrates using TypeScript with the [ArcGIS Maps SDK for JavaScript](https://developers.arcgis.com/javascript/) AMD modules. The TypeScript file `main.ts` is converted to JavaScript, and the `import` statements are converted to AMD by the TypeScript compiler. When you run the application, it uses the SDK's AMD modules from the [ArcGIS CDN](https://developers.arcgis.com/javascript/latest/install-and-set-up/#amd-modules-via-arcgis-cdn).
 
 ## Usage
 
 1. Clone the repo and `npm install` dependencies
 2. `npm run dev` to compile `/app/main.ts` to `main.js` in the same folder and watch for changes
-3. launch `index.html` in your browser of choice.
+3. Launch `index.html` in your browser of choice.

--- a/4.x/typescript/demo/index.html
+++ b/4.x/typescript/demo/index.html
@@ -13,7 +13,7 @@
         width: 100%;
       }
     </style>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.23/esri/themes/light/main.css">
+    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css">
     <script>
       var locationPath = location.pathname.replace(/\/[^/]*$/, "");
       window.dojoConfig = {
@@ -25,7 +25,7 @@
         ]
       };
     </script>
-    <script src="https://js.arcgis.com/4.23"></script>
+    <script src="https://js.arcgis.com/4.27"></script>
   </head>
   <body>
     <div id="viewDiv"></div>

--- a/4.x/typescript/demo/package.json
+++ b/4.x/typescript/demo/package.json
@@ -6,11 +6,7 @@
     "dev": "tsc -w",
     "build": "tsc"
   },
-  "dependencies": {
-    "arcgis-js-api": "^4.23.0"
-  },
   "devDependencies": {
-    "@types/arcgis-js-api": "^4.23.0",
-    "typescript": "^4.6.3"
+    "typescript": "^5.1.6"
   }
 }

--- a/4.x/typescript/demo/tsconfig.json
+++ b/4.x/typescript/demo/tsconfig.json
@@ -3,19 +3,12 @@
     "module": "amd",
     "noImplicitAny": true,
     "esModuleInterop": true,
-    "lib": ["DOM","ES2020"],    
-    "jsx": "react",
-    "jsxFactory": "tsx",
-    "target": "es5",
-    "experimentalDecorators": true,
-    "preserveConstEnums": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "lib": ["DOM","ES2020"],
+    "target": "ES2020",
     "moduleResolution": "node"
   },
   "include": [
+    "../*.d.ts",
     "./app/*"
-  ],
-  "exclude": [
-    "node_modules"
   ]
 }


### PR DESCRIPTION
Made the following updates to the demo app:
- Switched from using NPM installed type defs to using the local `.d.ts` file in the `4.x/TypeScript` directory
- Removed `arcgis-js-api` and `@types/arcgis-js-api` from the dependencies
- Added some clarification wording in the READMEs
- Scaled down the tsconfig
- Updated sample to use CDN version 4.27
- Added license info
- Updated TS version to 5.x