### PR TITLE
chore: update samples to 4.28

### DIFF
--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -24,15 +24,9 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 
 ## Get Started
 
-**Step 1** - Run `npm install` and then start adding modules.
+Run `npm install` and then start adding modules.
 
-**Step 2** Configure CSS.
-
-*styles.css*
-
-```css
-  @import 'https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css';
-```
+For a list of all available `npm` commands see `scripts` in `package.json`.
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
 
@@ -43,10 +37,6 @@ Currently, due to limitations in TypeScript, the APIs [autocasting](https://deve
 This sample implements strict class initalization, for more information visit the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#strict-class-initialization) page.
 
 Check the online Angular documentation for their minimum TypeScript requirements for each release.
-
-## Commands
-
-For a list of all available `npm` commands see the scripts in `package.json`. 
 
 ### Development server
 

--- a/esm-samples/jsapi-angular-cli/package.json
+++ b/esm-samples/jsapi-angular-cli/package.json
@@ -9,30 +9,26 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^16.0.0",
-    "@angular/common": "^16.0.0",
-    "@angular/compiler": "^16.0.0",
-    "@angular/core": "^16.0.0",
-    "@angular/forms": "^16.0.0",
-    "@angular/platform-browser": "^16.0.0",
-    "@angular/platform-browser-dynamic": "^16.0.0",
-    "@angular/router": "^16.0.0",
-    "@arcgis/core": "~4.27.0",
+    "@angular/animations": "^16.2.0",
+    "@angular/common": "^16.2.0",
+    "@angular/compiler": "^16.2.0",
+    "@angular/core": "^16.2.0",
+    "@angular/forms": "^16.2.0",
+    "@angular/platform-browser": "^16.2.0",
+    "@angular/platform-browser-dynamic": "^16.2.0",
+    "@angular/router": "^16.2.0",
+    "@arcgis/core": "~4.28.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.13.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^16.0.2",
-    "@angular/cli": "~16.0.2",
-    "@angular/compiler-cli": "^16.0.0",
-    "@types/jasmine": "~4.3.0",
-    "jasmine-core": "~4.6.0",
+    "@angular-devkit/build-angular": "^16.2.1",
+    "@angular/cli": "~16.2.1",
+    "@angular/compiler-cli": "^16.2.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
-    "karma-jasmine": "~5.1.0",
-    "karma-jasmine-html-reporter": "~2.0.0",
-    "typescript": "~5.0.2"
+    "typescript": "~5.1.3"
   }
 }

--- a/esm-samples/jsapi-angular-cli/src/app/app.component.css
+++ b/esm-samples/jsapi-angular-cli/src/app/app.component.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/light/main.css';
 .esri-view {
   padding: 0;
   margin: 0;

--- a/esm-samples/jsapi-custom-ui/README.md
+++ b/esm-samples/jsapi-custom-ui/README.md
@@ -6,18 +6,8 @@ The component in this sample is created in [JSX](https://react.dev/learn/writing
 
 ## Get Started
 
-**Step 1** - Run `npm install`
+Run `npm install` and then start adding modules.
 
-**Step 2** Configure CSS. 
+For a list of all available `npm` commands see `scripts` in `package.json`.
 
-*index.css*
-
-```css
-@import 'https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/light/main.css';
-```
-
-For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the  SDK.
-
-## Commands
-
-For a list of all available npm script commands, see the scripts in `package.json` or use `npm run`.
+For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.

--- a/esm-samples/jsapi-custom-ui/README.md
+++ b/esm-samples/jsapi-custom-ui/README.md
@@ -1,8 +1,8 @@
 # Custom UI component with React and Vite
 
-This repo demonstrates creating a custom UI component using [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with [React](https://react.dev/learn) and [Vite](https://vitejs.dev/guide/#community-templates). You can also use any other major JavaScript framework. For more information about building custom UI with the ArcGIS JS SDK, see the [Custom UI basics](https://developers.arcgis.com/javascript/latest/custom-ui/) guide topic.
+This repo demonstrates creating a custom UI component using [@arcgis/core](https://www.npmjs.com/package/@arcgis/core) ES modules with [React](https://react.dev/learn) and [Vite](https://vitejs.dev/guide/#community-templates). You can also use any other major JavaScript framework. For more information about building custom UI with the ArcGIS Maps SDK for JavaScript, see the [Custom UI basics](https://developers.arcgis.com/javascript/latest/custom-ui/) guide topic.
 
-The component in this sample is created in [JSX](https://react.dev/learn/writing-markup-with-jsx) and then added to the Map as a DOM element using the ArcGIS JS SDK's [View UI](https://developers.arcgis.com/javascript/latest/view-ui/) interface. This approach loosely couples the component with the functionality in the ArcGIS Maps SDK for JavaScript. It provides seamless integration with your preferred component library, and gives you full control over the user experience and component-life cycle so that it fits your unique requirements.
+The component in this sample is created in [JSX](https://react.dev/learn/writing-markup-with-jsx) and then added to the Map as a DOM element using the ArcGIS JS SDK's [View UI](https://developers.arcgis.com/javascript/latest/view-ui/) interface. This approach loosely couples the component with the functionality in the SDK. It provides seamless integration with your preferred component library, and gives you full control over the user experience and component lifecycle so that it fits your unique requirements.
 
 ## Get Started
 
@@ -13,10 +13,10 @@ The component in this sample is created in [JSX](https://react.dev/learn/writing
 *index.css*
 
 ```css
-@import 'https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/light/main.css';
 ```
 
-For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
+For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the  SDK.
 
 ## Commands
 

--- a/esm-samples/jsapi-custom-ui/package.json
+++ b/esm-samples/jsapi-custom-ui/package.json
@@ -4,18 +4,18 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build", 
+    "build": "vite build",
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "~4.27.0",
+    "@arcgis/core": "~4.28.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.28",
-    "@types/react-dom": "^18.0.11",
-    "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^4.3.2"
+    "@types/react": "^18.2.27",
+    "@types/react-dom": "^18.2.12",
+    "@vitejs/plugin-react": "^4.1.0",
+    "vite": "^4.4.11"
   }
 }

--- a/esm-samples/jsapi-custom-ui/src/index.css
+++ b/esm-samples/jsapi-custom-ui/src/index.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/light/main.css';
 html,
 body,
 #root {

--- a/esm-samples/jsapi-custom-workers/README.md
+++ b/esm-samples/jsapi-custom-workers/README.md
@@ -51,7 +51,7 @@ import * as workers from "@arcgis/core/core/workers.js";
 config.workers.workerPath = "./RemoteClient.js";
 
 // what loader to use, in this case SystemJS
-config.workers.loaderUrl = "https://cdn.jsdelivr.net/npm/systemjs@6.14.1/dist/s.min.js";
+config.workers.loaderUrl = "https://cdn.jsdelivr.net/npm/systemjs@6.14.2/dist/s.min.js";
 ...
   const results1= await layerView1.queryFeatures(query);
   const results2 = await layerView2.queryFeatures(query);
@@ -104,15 +104,3 @@ For additional information, see the [Build with ES modules](https://developers.a
 ## Commands
 
 For a list of all available `npm` commands see the scripts in `package.json`. 
-
-### development
-
-```
-npm run dev
-```
-
-### production
-
-```
-npm run build
-```

--- a/esm-samples/jsapi-custom-workers/README.md
+++ b/esm-samples/jsapi-custom-workers/README.md
@@ -99,8 +99,10 @@ export function doSpatialJoin([f1, f2]) {
 
 For more details on using `@arcgis/core/core/workers`, you can review the [documentation](https://developers.arcgis.com/javascript/latest/api-reference/esri-core-workers.html).
 
+## Getting started
+
+Run `npm install` and then start adding modules.
+
+For a list of all available `npm` commands see `scripts` in `package.json`.
+
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
-
-## Commands
-
-For a list of all available `npm` commands see the scripts in `package.json`. 

--- a/esm-samples/jsapi-custom-workers/package.json
+++ b/esm-samples/jsapi-custom-workers/package.json
@@ -1,19 +1,19 @@
 {
   "private": true,
   "devDependencies": {
-    "@arcgis/core": "~4.27.0",
-    "@rollup/plugin-node-resolve": "^15.0.2",
-    "@rollup/plugin-terser": "^0.4.3",
-    "css-loader": "^6.7.4",
+    "@arcgis/core": "~4.28.0",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-terser": "^0.4.4",
+    "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",
-    "html-webpack-plugin": "^5.5.1",
+    "html-webpack-plugin": "^5.5.3",
     "mini-css-extract-plugin": "^2.7.6",
     "npm-run-all": "^4.1.5",
-    "rollup": "^3.23.0",
+    "rollup": "^4.0.2",
     "source-map-loader": "^4.0.1",
-    "webpack": "^5.84.1",
-    "webpack-cli": "^5.1.1",
-    "webpack-dev-server": "^4.15.0"
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
   },
   "scripts": {
     "build": "npm-run-all clean --parallel build:*",

--- a/esm-samples/jsapi-custom-workers/src/index.css
+++ b/esm-samples/jsapi-custom-workers/src/index.css
@@ -1,4 +1,4 @@
-@import "https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/dark/main.css";
+@import "https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/dark/main.css";
 html,
 body,
 #viewDiv {

--- a/esm-samples/jsapi-custom-workers/src/index.js
+++ b/esm-samples/jsapi-custom-workers/src/index.js
@@ -10,7 +10,7 @@ import * as workers from "@arcgis/core/core/workers.js";
 
 config.workers.workerPath = "./RemoteClient.js";
 
-config.workers.loaderUrl = "https://cdn.jsdelivr.net/npm/systemjs@6.14.1/dist/s.min.js";
+config.workers.loaderUrl = "https://cdn.jsdelivr.net/npm/systemjs@6.14.2/dist/s.min.js";
 
 const button1 = document.getElementById("btn-1");
 

--- a/esm-samples/jsapi-deno/README.md
+++ b/esm-samples/jsapi-deno/README.md
@@ -1,12 +1,12 @@
 # ArcGIS Maps SDK for JavaScript in Deno
 
-Integrating [Deno](https://deno.land/) with [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) can be done by using [TypeScript](https://www.typescriptlang.org/) with no compile steps.
+Integrating [Deno](https://deno.com//) with [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/core) can be done by using [TypeScript](https://www.typescriptlang.org/) with no compile steps.
 
-Please refer to the [Deno installation](https://deno.com/manual@v1.34.0/getting_started) instructions for your environment.
+Please refer to the [Deno installation](https://docs.deno.com/runtime/manual/getting_started) instructions for your environment.
 
 ## Usage
 
-The `@arcgis/core` package can be referenced with [npm specifiers](https://deno.com/manual@v1.34.0/node/npm_specifiers), meaning you do not need to manually install the package in your projects.
+The `@arcgis/core` package can be referenced with [npm specifiers](https://docs.deno.com/runtime/manual/node/npm_specifiers), meaning you do not need to manually install the package in your projects.
 
 
 ## Notes

--- a/esm-samples/jsapi-deno/request.ts
+++ b/esm-samples/jsapi-deno/request.ts
@@ -1,7 +1,7 @@
 // @deno-types="npm:@arcgis/core/interfaces.d.ts"
-import { Application, Context } from "https://deno.land/x/oak@v12.5.0/mod.ts";
-import config from "npm:@arcgis/core@4.27/config.js";
-import esriRequest from "npm:@arcgis/core@4.27/request.js";
+import { Application, Context } from "https://deno.land/x/oak@v12.6.1/mod.ts";
+import config from "npm:@arcgis/core@4.28/config.js";
+import esriRequest from "npm:@arcgis/core@4.28/request.js";
 
 config.request.useIdentity = false;
 

--- a/esm-samples/jsapi-deno/webmap.ts
+++ b/esm-samples/jsapi-deno/webmap.ts
@@ -1,7 +1,7 @@
 // @deno-types="npm:@arcgis/core/interfaces.d.ts"
-import { Application, Context } from "https://deno.land/x/oak@v12.5.0/mod.ts";
-import config from "npm:@arcgis/core@4.27/config.js";
-import WebMap from "npm:@arcgis/core@4.27/WebMap.js";
+import { Application, Context } from "https://deno.land/x/oak@v12.6.1/mod.ts";
+import config from "npm:@arcgis/core@4.28/config.js";
+import WebMap from "npm:@arcgis/core@4.28/WebMap.js";
 
 config.request.useIdentity = false;
 

--- a/esm-samples/jsapi-esm-cdn/README.md
+++ b/esm-samples/jsapi-esm-cdn/README.md
@@ -1,6 +1,6 @@
 # ArcGIS Maps SDK for JavaScript ES modules via CDN
 
-We currently recommend only using the ES modules (ESM) via CDN for testing and prototyping. The ESM CDN build isn't optimized for fast loading. 
+We currently recommend only using the ES modules (ESM) via CDN for testing and prototyping. The ESM CDN hasn't been built, and is not optimized for fast loading. 
 
 For best performance either build the ES modules locally or use [AMD modules via the ArcGIS CDN](https://developers.arcgis.com/javascript/latest/install-and-set-up/#amd-modules-via-arcgis-cdn).
 

--- a/esm-samples/jsapi-esm-cdn/esm-cdn.html
+++ b/esm-samples/jsapi-esm-cdn/esm-cdn.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no" />
   <title>ArcGIS ESM CDN</title>
 
-  <link rel="stylesheet" href="https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css" />
+  <link rel="stylesheet" href="https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/light/main.css" />
 
   <style>
     html,
@@ -19,10 +19,10 @@
     }
   </style>
   <script type="module">
-    import WebMap from 'https://js.arcgis.com/4.27/@arcgis/core/WebMap.js';
-    import MapView from 'https://js.arcgis.com/4.27/@arcgis/core/views/MapView.js';
-    import Bookmarks from 'https://js.arcgis.com/4.27/@arcgis/core/widgets/Bookmarks.js';
-    import Expand from 'https://js.arcgis.com/4.27/@arcgis/core/widgets/Expand.js';
+    import WebMap from 'https://js.arcgis.com/4.28/@arcgis/core/WebMap.js';
+    import MapView from 'https://js.arcgis.com/4.28/@arcgis/core/views/MapView.js';
+    import Bookmarks from 'https://js.arcgis.com/4.28/@arcgis/core/widgets/Bookmarks.js';
+    import Expand from 'https://js.arcgis.com/4.28/@arcgis/core/widgets/Expand.js';
 
     const webmap = new WebMap({
       portalItem: {

--- a/esm-samples/jsapi-node/README.md
+++ b/esm-samples/jsapi-node/README.md
@@ -11,7 +11,7 @@ Integrating Node.js with [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/
 ---
 
 ## Get Started
-Make sure you are running Node 18.16+ or greater: `node -v`.
+Make sure you are running Node 18.16.1 or greater: `node -v`.
 
 To run a test app, execute these commands in a terminal window:
 1. `npm install` - install the modules

--- a/esm-samples/jsapi-node/README.md
+++ b/esm-samples/jsapi-node/README.md
@@ -4,8 +4,9 @@ Integrating Node.js with [`@arcgis/core`](https://www.npmjs.com/package/@arcgis/
 
 ---
 ## Known Issues
-
+ 
 * Using the SDK's [projection engine](https://developers.arcgis.com/javascript/latest/api-reference/esri-geometry-projection.html) in Node.js requires transpiling to CJS and using a local copy of the SDK's assets.
+* If you are getting the error `ReferenceError: crypto is not defined` and you are using Node 18, use the `--experimental-global-webcrypto` flag.
 * If you are getting the error `TypeError: Cannot read properties of undefined (reading 'bind')`, try upgrading to Node 18.16+ or use the `--experimental-fetch` flag, for example: `node --experimental-fetch test-request.js` or `node --experimental-fetch test-webmap.js`.
 
 ---

--- a/esm-samples/jsapi-node/package.json
+++ b/esm-samples/jsapi-node/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "~4.27.0",
-    "rollup-plugin-copy": "^3.4.0",
+    "@arcgis/core": "~4.28.0",
+    "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-delete": "^2.0.0"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^15.0.2",
-    "rollup": "^3.23.0"
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "rollup": "^4.0.2"
   },
   "scripts": {
     "build": "rollup -c"

--- a/esm-samples/jsapi-react/README.md
+++ b/esm-samples/jsapi-react/README.md
@@ -11,7 +11,7 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 _index.css_
 
 ```css
-@import "https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css";
+@import "https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/light/main.css";
 ```
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
@@ -23,7 +23,7 @@ For a list of all available `npm` commands see the scripts in `package.json`.
 This project was bootstrapped with [Vite](https://vitejs.dev/).
 
 ## Learn More
-s
+
 You can learn more in the [Vite guides](https://vitejs.dev/guide/).
 
 To learn React, check out the [React documentation](https://reactjs.org/).

--- a/esm-samples/jsapi-react/README.md
+++ b/esm-samples/jsapi-react/README.md
@@ -4,23 +4,11 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 
 ## Get Started
 
-**Step 1** - Run `npm install` and then start adding modules.
+Run `npm install` and then start adding modules.
 
-**Step 2** Configure CSS.
-
-_index.css_
-
-```css
-@import "https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/light/main.css";
-```
+For a list of all available `npm` commands see `scripts` in `package.json`.
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
-
-## Commands
-
-For a list of all available `npm` commands see the scripts in `package.json`.
-
-This project was bootstrapped with [Vite](https://vitejs.dev/).
 
 ## Learn More
 

--- a/esm-samples/jsapi-react/package.json
+++ b/esm-samples/jsapi-react/package.json
@@ -10,14 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "~4.27.0",
+    "@arcgis/core": "~4.28.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/react": "^18.2.7",
-    "@types/react-dom": "^18.2.4",
-    "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^4.3.9"
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.13",
+    "@vitejs/plugin-react": "^4.1.0",
+    "vite": "^4.4.11"
   }
 }

--- a/esm-samples/jsapi-react/src/App.jsx
+++ b/esm-samples/jsapi-react/src/App.jsx
@@ -50,7 +50,7 @@ function App() {
         }
       });
     }
-  }, []);
+  }, [mapDiv]);
 
   return <div className="mapDiv" ref={mapDiv}></div>;
 }

--- a/esm-samples/jsapi-vite-ts/README.md
+++ b/esm-samples/jsapi-vite-ts/README.md
@@ -4,21 +4,11 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 
 ## Get Started
 
-**Step 1** - Run `npm install` and then start adding modules.
+Run `npm install` and then start adding modules.
 
-**Step 2** Configure CSS.
-
-_styles.css_
-
-```css
-@import "https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css";
-```
+For a list of all available `npm` commands see `scripts` in `package.json`.
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
-
-## Commands
-
-For a list of all available `npm` commands see the scripts in `package.json`.
 
 ## Learn More
 

--- a/esm-samples/jsapi-vite-ts/package.json
+++ b/esm-samples/jsapi-vite-ts/package.json
@@ -9,10 +9,10 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "typescript": "^5.0.2",
-    "vite": "^4.3.9"
+    "typescript": "^5.2.2",
+    "vite": "^4.4.11"
   },
   "dependencies": {
-    "@arcgis/core": "~4.27.0"
+    "@arcgis/core": "~4.28.0"
   }
 }

--- a/esm-samples/jsapi-vue/README.md
+++ b/esm-samples/jsapi-vue/README.md
@@ -4,25 +4,15 @@ This repo demonstrates how to use [@arcgis/core](https://www.npmjs.com/package/@
 
 ## Get Started
 
-**Step 1** - Run `npm install` and then start adding modules.
+Run `npm install` and then start adding modules.
 
-**Step 2** Configure CSS.
-
-*main.css*
-
-```css
-  @import 'https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css';
-```
+For a list of all available `npm` commands see `scripts` in `package.json`.
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
 
 ## Production builds
 
 See the [VueJS Deployment](https://cli.vuejs.org/guide/deployment.html#deployment) guide.
-
-## Commands
-
-For a list of all available `npm` commands see the scripts in `package.json`.
 
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/esm-samples/jsapi-vue/package.json
+++ b/esm-samples/jsapi-vue/package.json
@@ -7,11 +7,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@arcgis/core": "~4.27.0",
+    "@arcgis/core": "~4.28.0",
     "vue": "^3.3.4"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^4.2.3",
-    "vite": "^4.3.9"
+    "@vitejs/plugin-vue": "^4.4.0",
+    "vite": "^4.4.11"
   }
 }

--- a/esm-samples/jsapi-vue/src/main.css
+++ b/esm-samples/jsapi-vue/src/main.css
@@ -1,4 +1,4 @@
-@import 'https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css';
+@import 'https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/light/main.css';
 html,
 body,
 #app {

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -65,3 +65,7 @@ This example can also be used with TypeScript sources. The following steps conve
 }
 ```
 6. Note that the watch feature of `npm start` will not catch your TypeScript changes; you need to use `npm run watch` instead.
+
+## Experimental
+
+In `rollup.config.prod.js`, you can try fine tuning the [`output.experimentalMinChunkSize`](https://rollupjs.org/configuration-options/#output-experimentalminchunksize). Using a setting of `100_000` with this sample resulted in a roughly 17% reduction in the number of `.js` files requested. Depending on your application and other environment factors such as internet download speeds, this may result in a slight decrease in loading time.

--- a/esm-samples/rollup/README.md
+++ b/esm-samples/rollup/README.md
@@ -9,21 +9,11 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 
 ## Get Started
 
-**Step 1** - Run `npm install` and then start adding modules
+Run `npm install` and then start adding modules.
 
-**Step 2** Configure CSS. Here's a basic HTML example:
-
-*index.html*
-
-```html
- <link rel="stylesheet" href="https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css>
-```
+For a list of all available `npm` commands see `scripts` in `package.json`.
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
-
-## Commands
-
-For a list of all available `npm` commands see the scripts in `package.json`.
 
 ## TypeScript
 This example can also be used with TypeScript sources. The following steps convert the example into a TypeScript starter.

--- a/esm-samples/rollup/package.json
+++ b/esm-samples/rollup/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "jsapi-rollup",  
+  "name": "jsapi-rollup",
   "private": true,
   "type": "module",
   "dependencies": {
-    "@arcgis/core": "~4.27.0"
+    "@arcgis/core": "~4.28.0"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^25.0.0",
-    "@rollup/plugin-node-resolve": "^15.1.0",
-    "@rollup/plugin-terser": "~0.4.3",
-    "rollup": "^3.23.0",
+    "@rollup/plugin-commonjs": "^25.0.5",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-terser": "~0.4.4",
+    "rollup": "^4.0.2",
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-livereload": "^2.0.5",
     "rollup-plugin-serve": "^2.0.2"

--- a/esm-samples/rollup/public/index.html
+++ b/esm-samples/rollup/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Rollup Sample</title>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.26/@arcgis/core/assets/esri/themes/dark/main.css" />
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/@arcgis/core/assets/esri/themes/dark/main.css" />
     <style>
       html,
       body,

--- a/esm-samples/webpack/README.md
+++ b/esm-samples/webpack/README.md
@@ -64,18 +64,8 @@ This repo demonstrates how to use the [`@arcgis/core`](https://www.npmjs.com/pac
 
 ## Get Started
 
-**Step 1** - Run `npm install` and then start adding modules.
+Run `npm install` and then start adding modules.
 
-**Step 2** Configure CSS. Here's a basic CSS example:
-
-*index.css*
-
-```css
-@import 'https://js.arcgis.com/4.27/@arcgis/core/assets/esri/themes/light/main.css';
-```
+For a list of all available `npm` commands see `scripts` in `package.json`.
 
 For additional information, see the [Build with ES modules](https://developers.arcgis.com/javascript/latest/es-modules/) Guide topic in the SDK.
-
-## Commands
-
-For a list of all available `npm` commands see the scripts in `package.json`.

--- a/esm-samples/webpack/package.json
+++ b/esm-samples/webpack/package.json
@@ -1,17 +1,17 @@
 {
   "private": true,
   "dependencies": {
-    "@arcgis/core": "~4.27.0"
+    "@arcgis/core": "~4.28.0"
   },
   "devDependencies": {
     "css-loader": "^6.8.1",
     "file-loader": "^6.2.0",
-    "html-webpack-plugin": "^5.5.1",
+    "html-webpack-plugin": "^5.5.3",
     "mini-css-extract-plugin": "^2.7.6",
     "source-map-loader": "^4.0.1",
-    "webpack": "^5.85.0",
-    "webpack-cli": "^5.1.1",
-    "webpack-dev-server": "^4.15.0"
+    "webpack": "^5.88.2",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
   },
   "scripts": {
     "build": "webpack --mode production",

--- a/typescript/demo/index.html
+++ b/typescript/demo/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1,user-scalable=no"/>
-    <title>TypeScript Demo - ArcGIS Maps SDK for JavaScript</title>
+    <title>AMD TypeScript Demo - ArcGIS Maps SDK for JavaScript</title>
     <style>
       html,
       body,
@@ -13,7 +13,7 @@
         width: 100%;
       }
     </style>
-    <link rel="stylesheet" href="https://js.arcgis.com/4.27/esri/themes/light/main.css">
+    <link rel="stylesheet" href="https://js.arcgis.com/4.28/esri/themes/light/main.css">
     <script>
       var locationPath = location.pathname.replace(/\/[^/]*$/, "");
       window.dojoConfig = {
@@ -25,7 +25,7 @@
         ]
       };
     </script>
-    <script src="https://js.arcgis.com/4.27"></script>
+    <script src="https://js.arcgis.com/4.28"></script>
   </head>
   <body>
     <div id="viewDiv"></div>

--- a/typescript/demo/package.json
+++ b/typescript/demo/package.json
@@ -7,6 +7,6 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   }
 }


### PR DESCRIPTION
Items not in this PR:
* `@types/arcgis-js-api deprecation
* `arcgis-js-api-4.28.d.ts` file 