### PR TITLE
chore(angular): add browserslistrc

### DIFF
--- a/esm-samples/jsapi-angular-cli/.browserslistrc
+++ b/esm-samples/jsapi-angular-cli/.browserslistrc
@@ -1,0 +1,6 @@
+last 4 chrome versions
+last 4 edge versions
+last 2 ff versions
+firefox esr
+last 2 safari major versions
+last 2 ios major versions


### PR DESCRIPTION
Override Angular's default browerslist to suppress warning message that showed up at Angular 15. We've added and removed this list over time, and now it's back again.

```
One or more browsers which are configured in the project's Browserslist configuration will be ignored as ES5 output is not supported by the Angular CLI.
Ignored browsers: bb 10, bb 7, ie 11, ie 10, ie_mob 11, ie_mob 10, kaios 2.5, op_mini all
```

References: https://angular.io/guide/build#configuring-browser-compatibility. 

/cc @odoe 