### PR TITLE
chore(angular): various updates

### DIFF
--- a/esm-samples/.metrics/4.28.0.csv
+++ b/esm-samples/.metrics/4.28.0.csv
@@ -1,6 +1,6 @@
 Sample,Build size (MB),Build file count,Main bundle file,Main bundle size (MB),Main bundle gzipped size (MB),Main bundle brotli compressed size (MB),Load time (ms),Total runtime (ms),Loaded size (MB),Total JS requests,Total HTTP requests,JS heap size (MB)
-Angular 17.0.0,8.55,276,main.0f4a0eade57aae2d.js,1.61,0.46,0.37,4135,14011,5.80,46,144,29.81
-React 18.2.0,7.57,412,index-v7nTMlmj.js,1.47,0.42,0.34,3521,13437,5.37,128,227,28.46
-Vue 3.4.11,7.48,412,index-of0VpgNx.js,1.39,0.40,0.32,3991,13483,5.26,128,227,28.49
-Rollup 4.1.4,7.30,411,main.js,1.30,0.36,0.29,3581,13365,5.14,128,226,26.61
-Webpack 5.89.0,8.76,271,index.js,1.40,0.38,0.31,3707,13515,5.52,40,139,27.23
+Angular 17.0.0,8.55,276,main.08e9ffcb9e8110f3.js,1.61,0.46,0.37,4295,14066,5.80,46,144,29.27
+React 18.2.0,7.57,412,index-T2jb7Mmj.js,1.47,0.42,0.34,3413,13302,5.37,128,227,26.06
+Vue 3.4.11,7.48,412,index-EJLp6mB2.js,1.39,0.40,0.32,3504,13302,5.26,128,226,25.05
+Rollup 4.1.4,7.30,411,main.js,1.30,0.36,0.29,3469,13258,5.13,128,225,23.78
+Webpack 5.89.0,8.76,271,index.js,1.40,0.38,0.31,3362,13243,5.52,40,139,26.22

--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -12,7 +12,7 @@ For a list of all available `npm` commands see `scripts` in `package.json`.
 
 * The Maps SDK compatibility with Webpack versions prior to `5.84.0` was deprecated at 4.27 and will be removed at 4.29 (Q1 2024).
 
-* When using Angular 17, for better application load performance with distribution builds it is recommended to use the Webpack builder `@angular-devkit/build-angular:browser` instead of the default esbuild configuration. This can be configured in the project's `angular.json` file. More information is available in the [Getting started with the Angular CLI's new build system](https://angular.io/guide/esbuild) page. At this time esbuild does not offer the ability to customize chunking. That may result in the creation of a significant number of small on-disk bundled files, as well as an increase in the number of files requested by the application at startup. Here is an example snippet:
+* When using Angular 17, for better application load performance with distribution builds it is recommended to use the Webpack builder `@angular-devkit/build-angular:browser` instead of the default esbuild configuration. This can be configured in the project's `angular.json` file. More information is available in the [Building Angular apps](https://angular.dev/tools/cli/build) on the angular.dev site. At this time esbuild does not offer the ability to customize chunking. That may result in the creation of a significant number of small on-disk bundled files, as well as an increase in the number of files requested by the application at startup. Here is an example snippet:
 
 *angular.json - Webpack configuration*
 

--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -12,7 +12,7 @@ For a list of all available `npm` commands see `scripts` in `package.json`.
 
 * The Maps SDK compatibility with Webpack versions prior to `5.84.0` was deprecated at 4.27 and will be removed at 4.29 (Q1 2024).
 
-* When using Angular 17, for better application load performance with distribution builds it is recommended to use the [Webpack builder](https://angular.io/guide/esbuild#using-the-application-builder) instead of the default esbuild configuration. This can be configured in the project's `angular.json` file. At this time esbuild does not offer the ability to customize chunking. That may result in the creation of a significant number of small on-disk bundled files, as well as an increase in the number of files requested by the application at startup. Here is an example snippet:
+* When using Angular 17, for better application load performance with distribution builds it is recommended to use the Webpack builder `@angular-devkit/build-angular:browser` instead of the default esbuild configuration. This can be configured in the project's `angular.json` file. More information is available in the [Getting started with the Angular CLI's new build system](https://angular.io/guide/esbuild) page. At this time esbuild does not offer the ability to customize chunking. That may result in the creation of a significant number of small on-disk bundled files, as well as an increase in the number of files requested by the application at startup. Here is an example snippet:
 
 *angular.json - Webpack configuration*
 

--- a/esm-samples/jsapi-angular-cli/README.md
+++ b/esm-samples/jsapi-angular-cli/README.md
@@ -12,7 +12,7 @@ For a list of all available `npm` commands see `scripts` in `package.json`.
 
 * The Maps SDK compatibility with Webpack versions prior to `5.84.0` was deprecated at 4.27 and will be removed at 4.29 (Q1 2024).
 
-* When using Angular 17, for better application load performance with distribution builds it is recommended to use the Webpack builder `@angular-devkit/build-angular:browser` instead of the default esbuild configuration. This can be configured in the project's `angular.json` file. More information is available in the [Building Angular apps](https://angular.dev/tools/cli/build) on the angular.dev site. At this time esbuild does not offer the ability to customize chunking. That may result in the creation of a significant number of small on-disk bundled files, as well as an increase in the number of files requested by the application at startup. Here is an example snippet:
+* When using Angular 17, for better application load performance with distribution builds it is recommended to use the Webpack builder `@angular-devkit/build-angular:browser` instead of the default esbuild configuration. This can be configured in the project's `angular.json` file. More information is available in the [Building Angular apps](https://angular.dev/tools/cli/build) topic on the angular.dev site. At this time esbuild does not offer the ability to customize chunking. That may result in the creation of a significant number of small on-disk bundled files, as well as an increase in the number of files requested by the application at startup. Here is an example snippet:
 
 *angular.json - Webpack configuration*
 

--- a/esm-samples/jsapi-angular-cli/package.json
+++ b/esm-samples/jsapi-angular-cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --force-esbuild",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"


### PR DESCRIPTION
Notable items:
* Enable esbuild for dev work (significantly faster!)
* Update the Known Issue verbiage for using webpack for production, and add a new link to angular.dev for better info on the builders options.

