### PR TITLE
chore(webpack): update devServer.port

### DIFF
--- a/esm-samples/webpack/webpack.config.js
+++ b/esm-samples/webpack/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = {
       directory: path.join(__dirname, 'dist'),
     },
     compress: true,
-    port: 3001,
+    port: 8080,
   },
   module: {
     rules: [


### PR DESCRIPTION
Changed the devServer port from 3001 to 8080 to avoid conflicts on Windows.

Reference: https://webpack.js.org/configuration/dev-server/#devserverport
