### PR TITLE
chore(Bookmarks): remove deprecated property

### DIFF
--- a/esm-samples/esbuild/src/index.js
+++ b/esm-samples/esbuild/src/index.js
@@ -15,9 +15,7 @@ const view = new MapView({
 });
 
 const bookmarks = new Bookmarks({
-  view,
-  // allows bookmarks to be added, edited, or deleted
-  editingEnabled: true
+  view
 });
 
 const bkExpand = new Expand({

--- a/esm-samples/jsapi-angular-cli/src/app/app.component.ts
+++ b/esm-samples/jsapi-angular-cli/src/app/app.component.ts
@@ -42,9 +42,7 @@ export class AppComponent implements OnInit, OnDestroy {
     });
 
     const bookmarks = new Bookmarks({
-      view: this.view,
-      // allows bookmarks to be added, edited, or deleted
-      editingEnabled: true,
+      view: this.view
     });
 
     const bkExpand = new Expand({

--- a/esm-samples/jsapi-custom-ui/src/App.jsx
+++ b/esm-samples/jsapi-custom-ui/src/App.jsx
@@ -27,8 +27,7 @@ function App() {
       });
 
       const bookmarks = new Bookmarks({
-        view,
-        editingEnabled: true
+        view
       });
 
       const bkExpand = new Expand({

--- a/esm-samples/jsapi-esm-cdn/esm-cdn.html
+++ b/esm-samples/jsapi-esm-cdn/esm-cdn.html
@@ -36,9 +36,7 @@
     });
 
     const bookmarks = new Bookmarks({
-      view,
-      // allows bookmarks to be added, edited, or deleted
-      editingEnabled: true,
+      view
     });
 
     const bkExpand = new Expand({

--- a/esm-samples/jsapi-react/src/App.jsx
+++ b/esm-samples/jsapi-react/src/App.jsx
@@ -27,9 +27,7 @@ function App() {
       });
 
       const bookmarks = new Bookmarks({
-        view,
-        // allows bookmarks to be added, edited, or deleted
-        editingEnabled: true
+        view
       });
 
       const bkExpand = new Expand({

--- a/esm-samples/jsapi-vite-ts/src/main.ts
+++ b/esm-samples/jsapi-vite-ts/src/main.ts
@@ -17,9 +17,7 @@ const view = new MapView({
 });
 
 const bookmarks = new Bookmarks({
-  view,
-  // allows bookmarks to be added, edited, or deleted
-  editingEnabled: true
+  view
 });
 
 const bkExpand = new Expand({

--- a/esm-samples/jsapi-vue/src/App.vue
+++ b/esm-samples/jsapi-vue/src/App.vue
@@ -24,9 +24,7 @@ export default {
     });
 
     const bookmarks = new Bookmarks({
-      view: view,
-      // allows bookmarks to be added, edited, or deleted
-      editingEnabled: true,
+      view: view
     });
 
     const bkExpand = new Expand({

--- a/esm-samples/rollup/src/main.js
+++ b/esm-samples/rollup/src/main.js
@@ -15,9 +15,7 @@ const view = new MapView({
 });
 
 const bookmarks = new Bookmarks({
-  view,
-  // allows bookmarks to be added, edited, or deleted
-  editingEnabled: true
+  view
 });
 
 const bkExpand = new Expand({

--- a/esm-samples/webpack/src/index.js
+++ b/esm-samples/webpack/src/index.js
@@ -15,9 +15,7 @@ const view = new MapView({
 });
 
 const bookmarks = new Bookmarks({
-  view,
-  // allows bookmarks to be added, edited, or deleted
-  editingEnabled: true
+  view
 });
 
 const bkExpand = new Expand({


### PR DESCRIPTION
Remove the `Bookmarks.editingEnabled` property from samples.