### PR TITLE
chore(GHA): update git diff on samples directories

### DIFF
--- a/.github/workflows/analyze-builds.yml
+++ b/.github/workflows/analyze-builds.yml
@@ -21,7 +21,7 @@ jobs:
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           # did any files change in component or core samples
           # compare against version before the last commit in the branch
-          samples_changed=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" HEAD^) -- "./core-samples" "./components")
+          samples_changed=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" HEAD^) -- "./core-samples" "./component-samples")
           if [ -z "$samples_changed" ]; then
             echo "no samples changed, skipping creation of zip files"
             echo "zipskip=true" >> $GITHUB_OUTPUT   

--- a/.github/workflows/analyze-builds.yml
+++ b/.github/workflows/analyze-builds.yml
@@ -20,7 +20,7 @@ jobs:
           # This step involves analyzing if any files changed in the branch, if so we'll create zip files
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           # did any files change in component or core samples
-          # compare against last commit in the branch
+          # compare against version before the last commit in the branch
           samples_changed=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" HEAD^) -- "./core-samples" "./components")
           if [ -z "$samples_changed" ]; then
             echo "no samples changed, skipping creation of zip files"

--- a/.github/workflows/analyze-builds.yml
+++ b/.github/workflows/analyze-builds.yml
@@ -20,7 +20,8 @@ jobs:
           # This step involves analyzing if any files changed in the branch, if so we'll create zip files
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           # did any files change in component or core samples
-          samples_changed=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" origin/main) -- "./core-samples" "./components")
+          # compare against last commit in the branch
+          samples_changed=$(git diff --name-only "$current_branch" $(git merge-base "$current_branch" HEAD^) -- "./core-samples" "./components")
           if [ -z "$samples_changed" ]; then
             echo "no samples changed, skipping creation of zip files"
             echo "zipskip=true" >> $GITHUB_OUTPUT   


### PR DESCRIPTION
* Modify the samples git diff to look for changes on the branch since the version before the last commit. Previously it was comparing against origin/main. This may have caused an accidental recursion in the github action, under certain circumstances.
* Also fix bug in one of the sample paths.