### PR TITLE
fix zip file URL

### DIFF
--- a/core-samples/jsapi-react/README.md
+++ b/core-samples/jsapi-react/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to use [@arcgis/core](https://www.npmjs.com/package
 
 ## Get Started
 
-📁 **[Click here to download this directory as a ZIP file](hhttps://esri.github.io/jsapi-resources/zips/core-sample-jsapi-react.zip)** 📁
+📁 **[Click here to download this directory as a ZIP file](https://esri.github.io/jsapi-resources/zips/core-sample-jsapi-react.zip)** 📁
 
 Run `npm install` and then start adding modules.
 


### PR DESCRIPTION
The download link to the zip file needs to be fixed to remove an extra 'h' at the beginning of the link.