### PR TITLE
chore(GHA): pin ubuntu version and refactor node support

### DIFF
--- a/.github/workflows/analyze-builds.yml
+++ b/.github/workflows/analyze-builds.yml
@@ -8,13 +8,13 @@ jobs:
   analyze:
     if: "!contains(github.event.pull_request.labels.*.name, 'draft') && github.actor!='dependabot-preview[bot]'"
     runs-on: ubuntu-latest
+    timeout-minutes: 30  
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.ESM_BUILD }}
-          node-version: 22
       - name: should create zip files
         id: verify
         run: |
@@ -94,3 +94,11 @@ jobs:
           git commit -m "ci: analyze core esm sample builds" || true
           git push origin ${{ github.event.pull_request.head.ref }}
           git status
+  errors:
+    runs-on: ubuntu-latest
+    needs: analyze
+    if: needs.analyze.result == 'failure' && failure()
+    steps:
+      - name: Capture error
+        run: |
+          echo "Error in the build analysis"          

--- a/.github/workflows/analyze-builds.yml
+++ b/.github/workflows/analyze-builds.yml
@@ -7,14 +7,16 @@ on:
 jobs:
   analyze:
     if: "!contains(github.event.pull_request.labels.*.name, 'draft') && github.actor!='dependabot-preview[bot]'"
-    runs-on: ubuntu-latest
-    timeout-minutes: 30  
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.ESM_BUILD }}
       - name: should create zip files
         id: verify
         run: |
@@ -101,4 +103,4 @@ jobs:
     steps:
       - name: Capture error
         run: |
-          echo "Error in the build analysis"          
+          echo "Error in the build analysis"


### PR DESCRIPTION
Temporarily pin Ubuntu until after release. Ubuntu 23.10+ has issues with puppeteer.

/cc @daniely2564 can you review? 

Here's the error for reference:

```text
Error: Failed to launch the browser process!
[2001:2001:0220/225852.882206:FATAL:zygote_host_impl_linux.cc(128)] No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro that has disabled unprivileged user namespaces with AppArmor, see https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md. Otherwise see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the (older) SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
[0220/225852.891176:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq: No such file or directory (2)
[0220/225852.891213:ERROR:file_io_posix.cc(145)] open /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq: No such file or directory (2)


TROUBLESHOOTING: https://pptr.dev/troubleshooting

    at ChildProcess.onClose (/home/runner/work/github-actions-tests/github-actions-tests/.github/scripts/node_modules/@puppeteer/browsers/lib/cjs/launch.js:314:24)
    at ChildProcess.emit (node:events:530:35)
    at ChildProcess._handle.onexit (node:internal/child_process:293:12)
```