### PR TITLE
chore(create-zips): update pathnames

### DIFF
--- a/.github/scripts/create-zips.js
+++ b/.github/scripts/create-zips.js
@@ -27,7 +27,7 @@ const SAMPLES_RELATIVE_PATH = "../../";
 const SAMPLE_DIRS = [
   { dir: "core-samples"},
   { dir: "component-samples/tutorials"},
-  { dir: "component-samples/"}
+  { dir: "component-samples"}
 ];
 
 /**


### PR DESCRIPTION
Use the new directory paths when zipping the esm samples.

We can modify this, as needed. It will create separate zips for each tutorial, as well as a single zip for all the tutorials, in its current configuration.